### PR TITLE
Use knative-serving namespace for kourier control-plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Kourier is passing the knative serving e2e and conformance tests:
 
 - [**Getting started**](#getting-started)
 - [**Features**](#features)
+- [**Deployment**](#deployment)
 - [**Development**](#development)
 - [**License**](#license)
 
@@ -60,6 +61,18 @@ kubectl port-forward --namespace kourier-system $(kubectl get pod -n kourier-sys
 
 curl -v -H "Host: helloworld-go.default.127.0.0.1.nip.io" http://localhost:8080
 ```
+
+## Deployment
+
+By default, the deployment of the Kourier components is split between two different namespaces:
+
+- Kourier control is deployed in the `knative-serving` namespace
+- The kourier gateways are deployed in the `kourier-system` namespace
+
+To change the Kourier gateway namespace, you will need to: 
+
+- Modify the `deploy/kourier-knative.yaml` file, and replace all the namespaces fields that have `kourier-system` with the desired namespace.
+- Set the `KOURIER_GATEWAY_NAMESPACE` env var in the kourier-control deployment to the new namespace.
 
 ## Features
 

--- a/conf/envoy-bootstrap.yaml
+++ b/conf/envoy-bootstrap.yaml
@@ -57,7 +57,7 @@ static_resources:
       connect_timeout: 1s
       hosts:
         - socket_address:
-            address: "kourier-control"
+            address: "kourier-control.knative-serving"
             port_value: 18000
       http2_protocol_options: {}
       type: STRICT_DNS

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -6,73 +6,6 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-logging
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-leader-election
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-data:
-  _example: |
-        ################################
-        #                              #
-        #    EXAMPLE CONFIGURATION     #
-        #                              #
-        ################################
-
-        # This block is not actually functional configuration,
-        # but serves to illustrate the available configuration
-        # options and document them in a way that is accessible
-        # to users that `kubectl edit` this config map.
-        #
-        # These sample configuration options may be copied out of
-        # this example block and unindented to be in the data block
-        # to actually change the configuration.
-
-        # resourceLock controls which API resource is used as the basis for the
-        # leader election lock. Valid values are:
-        #
-        # - leases -> use the coordination API
-        # - configmaps -> use configmaps
-        # - endpoints -> use endpoints
-        resourceLock: "leases"
-
-        # leaseDuration is how long non-leaders will wait to try to acquire the
-        # lock; 15 seconds is the value used by core kubernetes controllers.
-        leaseDuration: "15s"
-        # renewDeadline is how long a leader will try to renew the lease before
-        # giving up; 10 seconds is the value used by core kubernetes controllers.
-        renewDeadline: "10s"
-        # retryPeriod is how long the leader election client waits between tries of
-        # actions; 2 seconds is the value used by core kubernetes controllers.
-        retryPeriod: "2s"
-        # enabledComponents is a comma-delimited list of component names for which
-        # leader election is enabled. Valid values are:
-        # - controller
-        # - hpaautoscaler
-        # - certcontroller
-        # - istiocontroller
-        # - nscontroller
-        # - kourier
-  enabledComponents: kourier
----
-apiVersion: v1
 kind: Service
 metadata:
   name: kourier
@@ -157,7 +90,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: 3scale-kourier-control
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 spec:
@@ -183,6 +116,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KOURIER_GATEWAY_NAMESPACE
+              value: "kourier-system"
           ports:
           - name: http2-xds
             containerPort: 18000
@@ -194,7 +129,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: 3scale-kourier
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 rules:
@@ -218,7 +153,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: 3scale-kourier
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 ---
@@ -235,7 +170,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: 3scale-kourier
-    namespace: kourier-system
+    namespace: knative-serving
 ---
 apiVersion: v1
 kind: Service
@@ -258,7 +193,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kourier-control
-  namespace: kourier-system
+  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
 spec:
@@ -337,7 +272,7 @@ data:
           connect_timeout: 1s
           hosts:
             - socket_address:
-                address: "kourier-control"
+                address: "kourier-control.knative-serving"
                 port_value: 18000
           http2_protocol_options: {}
           type: STRICT_DNS

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,10 @@ const (
 	HTTPPortInternal  = uint32(8081)
 	HTTPSPortExternal = uint32(8443)
 
-	InternalKourierDomain    = "internalkourier"
+	InternalKourierDomain = "internalkourier"
+
+	GatewayNamespaceEnv = "KOURIER_GATEWAY_NAMESPACE"
+
 	ExtAuthzHostEnv          = "KOURIER_EXTAUTHZ_HOST"
 	ExtAuthzFailureModeEnv   = "KOURIER_EXTAUTHZ_FAILUREMODEALLOW"
 	ExtAuthzMaxRequestsBytes = "KOURIER_EXTAUTHZ_MAXREQUESTBYTES"

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -17,11 +17,12 @@ limitations under the License.
 package knative
 
 import (
+	"os"
+
+	"knative.dev/net-kourier/pkg/config"
 	networkingv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
-
-	"knative.dev/net-kourier/pkg/config"
 )
 
 func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
@@ -51,5 +52,13 @@ func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
 }
 
 func domainForServiceName(serviceName string) string {
-	return serviceName + "." + system.Namespace() + ".svc." + network.GetClusterDomainName()
+	return serviceName + "." + GetGatewayNamespace() + ".svc." + network.GetClusterDomainName()
+}
+
+func GetGatewayNamespace() string {
+	namespace := os.Getenv(config.GatewayNamespaceEnv)
+	if namespace == "" {
+		return system.Namespace()
+	}
+	return namespace
 }

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -31,7 +31,6 @@ import (
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/status"
 	"knative.dev/pkg/network"
-	"knative.dev/pkg/system"
 )
 
 func NewProbeTargetLister(logger *zap.SugaredLogger, endpointsLister corev1listers.EndpointsLister) status.ProbeTargetLister {
@@ -48,7 +47,7 @@ type gatewayPodTargetLister struct {
 
 func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]status.ProbeTarget, error) {
 
-	eps, err := l.endpointsLister.Endpoints(system.Namespace()).Get(config.InternalServiceName)
+	eps, err := l.endpointsLister.Endpoints(knative.GetGatewayNamespace()).Get(config.InternalServiceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get internal service: %w", err)
 	}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -1,5 +1,3 @@
-
-
 # Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,19 +15,20 @@
 # This script includes common functions for testing setup and teardown.
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
-export KOURIER_NAMESPACE=kourier-system
-export GATEWAY_NAMESPACE_OVERRIDE=$KOURIER_NAMESPACE
+export KOURIER_CONTROL_NAMESPACE=knative-serving
+export KOURIER_GATEWAY_NAMESPACE=kourier-system
+export GATEWAY_NAMESPACE_OVERRIDE=${KOURIER_GATEWAY_NAMESPACE}
 export GATEWAY_OVERRIDE=kourier
 
 # Setup resources.
 function test_setup() {
   echo ">> Setting up logging..."
   # Install kail if needed.
-  if ! which kail > /dev/null; then
-    bash <( curl -sfL https://raw.githubusercontent.com/boz/kail/master/godownloader.sh) -b "$GOPATH/bin"
+  if ! which kail >/dev/null; then
+    bash <(curl -sfL https://raw.githubusercontent.com/boz/kail/master/godownloader.sh) -b "$GOPATH/bin"
   fi
   # Capture all logs.
-  kail > ${ARTIFACTS}/k8s.log.txt &
+  kail >${ARTIFACTS}/k8s.log.txt &
   local kail_pid=$!
   # Clean up kail so it doesn't interfere with job shutting down
   add_trap "kill $kail_pid || true" EXIT
@@ -44,26 +43,26 @@ function test_setup() {
   echo ">> Bringing up Kourier"
   ko apply -f deploy/ || return 1
 
-  scale_controlplane 3scale-kourier-control 3scale-kourier-gateway
+  scale_deployment 3scale-kourier-control "${KOURIER_CONTROL_NAMESPACE}"
+  scale_deployment 3scale-kourier-gateway "${GATEWAY_NAMESPACE_OVERRIDE}"
 
   # Wait for pods to be running.
   echo ">> Waiting for Kourier components to be running..."
-  wait_until_pods_running "${KOURIER_NAMESPACE}" || return 1
-  wait_until_service_has_external_http_address "${KOURIER_NAMESPACE}" kourier || return 1
+  wait_until_pods_running "${KOURIER_CONTROL_NAMESPACE}" || return 1
+  wait_until_pods_running "${KOURIER_GATEWAY_NAMESPACE}" || return 1
+  wait_until_service_has_external_http_address "${KOURIER_GATEWAY_NAMESPACE}" kourier || return 1
 
   # Wait for a new leader controller to prevent race conditions during service reconciliation.
   wait_for_leader_controller || failed=1
 }
 
-function scale_controlplane() {
-  for deployment in "$@"; do
+function scale_deployment() {
     # Make sure all pods run in leader-elected mode.
-    kubectl -n "${KOURIER_NAMESPACE}" scale deployment "$deployment" --replicas=0 || failed=1
+    kubectl -n "$2" scale deployment "$1" --replicas=0 || failed=1
     # Give it time to kill the pods.
     sleep 5
     # Scale up components for HA tests
-    kubectl -n "${KOURIER_NAMESPACE}" scale deployment "$deployment" --replicas=2 || failed=1
-  done
+    kubectl -n "$2" scale deployment "$1" --replicas=2 || failed=1
 }
 
 # Add function call to trap
@@ -82,10 +81,10 @@ function add_trap() {
 
 function wait_for_leader_controller() {
   echo -n "Waiting for leader Controller"
-  for i in {1..150}; do  # timeout after 5 minutes
-    local leader=$(kubectl get lease -n "${KOURIER_NAMESPACE}" -ojsonpath='{.items[*].spec.holderIdentity}'  | cut -d"_" -f1 | grep "^3scale-kourier-control-" | head -1)
+  for i in {1..150}; do # timeout after 5 minutes
+    local leader=$(kubectl get lease -n "${KOURIER_CONTROL_NAMESPACE}" -ojsonpath='{.items[*].spec.holderIdentity}' | cut -d"_" -f1 | grep "^3scale-kourier-control-" | head -1)
     # Make sure the leader pod exists.
-    if [ -n "${leader}" ] && kubectl get pod "${leader}" -n "${KOURIER_NAMESPACE}" >/dev/null 2>&1; then
+    if [ -n "${leader}" ] && kubectl get pod "${leader}" -n "${KOURIER_CONTROL_NAMESPACE}" >/dev/null 2>&1; then
       echo -e "\nNew leader Controller has been elected"
       return 0
     fi

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -42,7 +42,7 @@ import (
 const namespace string = "default"
 const clusterURL string = "http://localhost:8080"
 const domain string = "127.0.0.1.nip.io"
-const kourierNamespace string = "kourier-system"
+const kourierNamespace string = "knative-serving"
 
 func TestKourierIntegration(t *testing.T) {
 	t.Skip("Skip for now until we figure out how to run these in the Knative infra")

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -37,7 +37,6 @@ kubectl apply -f deploy/kourier-knative.yaml
 kubectl patch deployment 3scale-kourier-control -n ${KNATIVE_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
 kubectl patch configmap/config-domain -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
-kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 retries=0
 while [[ $(kubectl get pods -n ${KOURIER_CONTROL_NAMESPACE} -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier control pod to be ready "

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 KNATIVE_NAMESPACE=knative-serving
-
+KOURIER_GATEWAY_NAMESPACE=kourier-system
+KOURIER_CONTROL_NAMESPACE=${KNATIVE_NAMESPACE}
 if ! command -v k3d >/dev/null; then
   echo "k3d binary not in path, install with: curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash"
   exit 1
@@ -33,12 +34,12 @@ KNATIVE_VERSION=v0.16.0
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
 kubectl apply -f deploy/kourier-knative.yaml
-kubectl patch deployment 3scale-kourier-control -n ${KOURIER_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+kubectl patch deployment 3scale-kourier-control -n ${KNATIVE_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
 kubectl patch configmap/config-domain -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
-
+kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 retries=0
-while [[ $(kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+while [[ $(kubectl get pods -n ${KOURIER_CONTROL_NAMESPACE} -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier control pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
@@ -49,7 +50,7 @@ while [[ $(kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-contro
 done
 
 retries=0
-while [[ $(kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+while [[ $(kubectl get pods -n ${KOURIER_GATEWAY_NAMESPACE} -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier gateway pod to be ready "
   sleep 10
   if [ $retries -ge 10 ]; then
@@ -60,4 +61,4 @@ while [[ $(kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-gatewa
 done
 
 # shellcheck disable=SC2046
-kubectl port-forward --namespace ${KOURIER_NAMESPACE} "$(kubectl get pod -n ${KOURIER_NAMESPACE} -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &
+kubectl port-forward --namespace ${KOURIER_GATEWAY_NAMESPACE} "$(kubectl get pod -n ${KOURIER_GATEWAY_NAMESPACE} -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &


### PR DESCRIPTION
* Kourier control now runs under the knative-serving namespace.
* We keep the kourier gateways running on the kourier-system namespace.
* Adds a new ENV var, KOURIER_GATEWAY_NAMESPACE to the control-plane, that allows us to change the namespace where the gateways are deployed. 
* Misc fixes/changes to the tests scripts to make it work under the new namespaces.
* Instructions on how to change the Kourier gateway namespace. 