### PR TITLE
Use HasSuffix for local domain check

### DIFF
--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -124,7 +124,7 @@ func getInternalDomains(rule v1alpha1.IngressRule, localDomainName string) []str
 	var res []string
 
 	for _, host := range rule.Hosts {
-		if strings.Contains(host, localDomainName) {
+		if strings.HasSuffix(host, localDomainName) {
 			res = append(res, host)
 		}
 	}
@@ -135,7 +135,7 @@ func getInternalDomains(rule v1alpha1.IngressRule, localDomainName string) []str
 func getExternalDomains(rule v1alpha1.IngressRule, localDomainName string) []string {
 	var res []string
 	for _, host := range rule.Hosts {
-		if !strings.Contains(host, localDomainName) {
+		if !strings.HasSuffix(host, localDomainName) {
 			res = append(res, host)
 		}
 	}


### PR DESCRIPTION
This patch make a tiny change which to use HasSuffix instead of
Contains for local domain check.