### PR TITLE
Enable beta tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,7 +23,7 @@ failed=0
 
 go_test_e2e -timeout=20m -parallel=12 \
   ./test/conformance \
-  --enable-beta --enable-alpha \
+  --enable-beta \
   --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Give the controller time to sync with the rest of the system components.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,6 +23,7 @@ failed=0
 
 go_test_e2e -timeout=20m -parallel=12 \
   ./test/conformance \
+  --enable-beta --enable-alpha \
   --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Give the controller time to sync with the rest of the system components.


### PR DESCRIPTION
This patch enables beta tests.

Part of https://github.com/knative-sandbox/net-kourier/issues/155

The alpha test needs to support RewriteHost so we cannot enable it yet.

/cc @jmprusi @davidor @mattmoor 