### PR TITLE
Stop expanding cluster local hosts

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -181,6 +181,8 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 
 		if knative.RuleIsExternal(rule, ingress.Spec.Visibility) {
 			res.externalVirtualHosts = append(res.externalVirtualHosts, &virtualHost)
+			// External should also be accessible internally
+			res.internalVirtualHosts = append(res.internalVirtualHosts, &virtualHost)
 		} else {
 			res.internalVirtualHosts = append(res.internalVirtualHosts, &virtualHost)
 		}

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -43,7 +43,6 @@ import (
 type IngressTranslator struct {
 	kubeclient      kubeclient.Interface
 	endpointsLister corev1listers.EndpointsLister
-	localDomainName string
 	tracker         tracker.Interface
 	logger          *zap.SugaredLogger
 }
@@ -58,12 +57,11 @@ type translatedIngress struct {
 	internalVirtualHosts []*route.VirtualHost
 }
 
-func NewIngressTranslator(kubeclient kubeclient.Interface, endpointsLister corev1listers.EndpointsLister, localDomainName string, tracker tracker.Interface,
+func NewIngressTranslator(kubeclient kubeclient.Interface, endpointsLister corev1listers.EndpointsLister, tracker tracker.Interface,
 	logger *zap.SugaredLogger) IngressTranslator {
 	return IngressTranslator{
 		kubeclient:      kubeclient,
 		endpointsLister: endpointsLister,
-		localDomainName: localDomainName,
 		tracker:         tracker,
 		logger:          logger,
 	}
@@ -161,10 +159,10 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 			return nil, nil
 		}
 
-		externalDomains := knative.ExternalDomains(rule, translator.localDomainName)
+		internalDomains, externalDomains := knative.Domains(rule)
 
 		// External should also be accessible internally
-		internalDomains := append(knative.InternalDomains(rule, translator.localDomainName), externalDomains...)
+		internalDomains = append(internalDomains, externalDomains...)
 
 		var virtualHost, internalVirtualHost route.VirtualHost
 		if extAuthzEnabled {

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -159,7 +159,12 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 			return nil, nil
 		}
 
-		internalDomains, externalDomains := knative.Domains(rule)
+		var internalDomains, externalDomains []string
+		if rule.Visibility == v1alpha1.IngressVisibilityClusterLocal {
+			internalDomains = knative.Domains(rule)
+		} else {
+			externalDomains = knative.Domains(rule)
+		}
 
 		// External should also be accessible internally
 		internalDomains = append(internalDomains, externalDomains...)

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -183,7 +183,6 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 			res.externalVirtualHosts = append(res.externalVirtualHosts, &virtualHost)
 		} else {
 			res.internalVirtualHosts = append(res.internalVirtualHosts, &virtualHost)
-
 		}
 	}
 

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -176,7 +176,7 @@ func TestIngressVisibility(t *testing.T) {
 		intDomains []string
 		visibility v1alpha1.IngressVisibility
 	}{{
-		name:       "exteranl visibility",
+		name:       "external visibility",
 		hosts:      []string{"hello.default.example.com"},
 		extDomains: []string{"hello.default.example.com", "hello.default.example.com:*"},
 		// External should also be accessible internally

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -121,7 +121,7 @@ func TestTrafficSplits(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), "cluster.local", &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
 
 	ingressTranslation, err := ingressTranslator.translateIngress(&ingress, false)
 	if err != nil {
@@ -192,7 +192,7 @@ func TestIngressWithTLS(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), "cluster.local", &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
 
 	translatedIngress, err := ingressTranslator.translateIngress(ingress, false)
 	if err != nil {
@@ -225,7 +225,7 @@ func TestReturnsErrorWhenTLSSecretDoesNotExist(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), "cluster.local", &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
 
 	_, err := ingressTranslator.translateIngress(ingress, false)
 

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -17,40 +17,26 @@ limitations under the License.
 package knative
 
 import (
-	"strings"
-
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
-	"knative.dev/pkg/network"
 )
 
-// Domains returns internal domains and external domains.
+// Domains returns domains.
 //
-// external domains returns domains with the following formats:
+// For example, external domains returns domains with the following formats:
 // 	- sub-route_host.namespace.example.com
 // 	- sub-route_host.namespace.example.com:*
-//
-// internal domains returns domains with the following formats:
-// 	- sub-route_host.namespace
-// 	- sub-route_host.namespace.svc
-// 	- sub-route_host.namespace.svc.cluster.local
-// 	- Each of the previous ones with ":*" appended
 //
 // Somehow envoy doesn't match properly gRPC authorities with ports.
 // The fix is to include ":*" in the domains.
 // This applies both for internal and external domains.
 // More info https://github.com/envoyproxy/envoy/issues/886
 //
-func Domains(rule v1alpha1.IngressRule) ([]string, []string) {
-	var internal, external []string
+func Domains(rule v1alpha1.IngressRule) []string {
+	var domains []string
 	for _, host := range rule.Hosts {
-		if strings.HasSuffix(host, network.GetClusterDomainName()) {
-			external = append(external, host, host+":*")
-		} else {
-			external = append(external, host, host+":*")
-		}
+		domains = append(domains, host, host+":*")
 	}
-
-	return internal, external
+	return domains
 }
 
 func RuleIsExternal(rule v1alpha1.IngressRule, ingressVisibility v1alpha1.IngressVisibility) bool {

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -19,10 +19,7 @@ package knative
 import (
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
-	ingress "knative.dev/networking/pkg/ingress"
 	"knative.dev/pkg/network"
 )
 
@@ -47,10 +44,7 @@ func Domains(rule v1alpha1.IngressRule) ([]string, []string) {
 	var internal, external []string
 	for _, host := range rule.Hosts {
 		if strings.HasSuffix(host, network.GetClusterDomainName()) {
-			expandedHosts := ingress.ExpandedHosts(sets.NewString(host)).List()
-			for _, h := range expandedHosts {
-				internal = append(internal, h, h+":*")
-			}
+			external = append(external, host, host+":*")
 		} else {
 			external = append(external, host, host+":*")
 		}

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -19,49 +19,44 @@ package knative
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	ingress "knative.dev/networking/pkg/ingress"
+	"knative.dev/pkg/network"
 )
 
+// Domains returns internal domains and external domains.
+//
+// external domains returns domains with the following formats:
+// 	- sub-route_host.namespace.example.com
+// 	- sub-route_host.namespace.example.com:*
+//
+// internal domains returns domains with the following formats:
+// 	- sub-route_host.namespace
+// 	- sub-route_host.namespace.svc
+// 	- sub-route_host.namespace.svc.cluster.local
+// 	- Each of the previous ones with ":*" appended
+//
 // Somehow envoy doesn't match properly gRPC authorities with ports.
 // The fix is to include ":*" in the domains.
 // This applies both for internal and external domains.
 // More info https://github.com/envoyproxy/envoy/issues/886
-
-func ExternalDomains(rule v1alpha1.IngressRule, localDomainName string) []string {
-	var res []string
-
+//
+func Domains(rule v1alpha1.IngressRule) ([]string, []string) {
+	var internal, external []string
 	for _, host := range rule.Hosts {
-		if !strings.Contains(host, localDomainName) {
-			res = append(res, host, host+":*")
+		if strings.HasSuffix(host, network.GetClusterDomainName()) {
+			expandedHosts := ingress.ExpandedHosts(sets.NewString(host)).List()
+			for _, h := range expandedHosts {
+				internal = append(internal, h, h+":*")
+			}
+		} else {
+			external = append(external, host, host+":*")
 		}
 	}
 
-	return res
-}
-
-// InternalDomains returns domains with the following formats:
-// 	- sub-route_host
-// 	- sub-route_host.namespace
-// 	- sub-route_host.namespace.svc
-// 	- Each of the previous ones with ":*" appended
-func InternalDomains(rule v1alpha1.IngressRule, localDomainName string) []string {
-	var res []string
-
-	for _, host := range rule.Hosts {
-		if strings.Contains(host, localDomainName) {
-			res = append(res, host, host+":*")
-
-			splits := strings.Split(host, ".")
-			domain := splits[0] + "." + splits[1]
-			res = append(res, domain, domain+":*")
-
-			domain = splits[0] + "." + splits[1] + ".svc"
-			res = append(res, domain, domain+":*")
-
-		}
-	}
-
-	return res
+	return internal, external
 }
 
 func RuleIsExternal(rule v1alpha1.IngressRule, ingressVisibility v1alpha1.IngressVisibility) bool {

--- a/pkg/knative/ingress_rule_test.go
+++ b/pkg/knative/ingress_rule_test.go
@@ -31,22 +31,14 @@ var testRule = v1alpha1.IngressRule{
 	},
 }
 
-func TestExternalDomains(t *testing.T) {
-	externalDomains := ExternalDomains(testRule, "cluster.local")
+func TestDomains(t *testing.T) {
+	internalDomains, externalDomains := Domains(testRule)
 
-	expected := []string{
+	extExpected := []string{
 		"helloworld-go.default.example.com",
 		"helloworld-go.default.example.com:*",
 	}
-	sort.Strings(externalDomains)
-	sort.Strings(expected)
-	assert.DeepEqual(t, externalDomains, expected)
-}
-
-func TestInternalDomains(t *testing.T) {
-	internalDomains := InternalDomains(testRule, "cluster.local")
-
-	expected := []string{
+	intExpected := []string{
 		"helloworld-go.default",
 		"helloworld-go.default:*",
 		"helloworld-go.default.svc",
@@ -54,9 +46,12 @@ func TestInternalDomains(t *testing.T) {
 		"helloworld-go.default.svc.cluster.local",
 		"helloworld-go.default.svc.cluster.local:*",
 	}
+	sort.Strings(intExpected)
+	sort.Strings(externalDomains)
 	sort.Strings(internalDomains)
-	sort.Strings(expected)
-	assert.DeepEqual(t, internalDomains, expected)
+	sort.Strings(extExpected)
+	assert.DeepEqual(t, externalDomains, extExpected)
+	assert.DeepEqual(t, internalDomains, intExpected)
 }
 
 func TestRuleIsExternalWithVisibility(t *testing.T) {

--- a/pkg/knative/ingress_rule_test.go
+++ b/pkg/knative/ingress_rule_test.go
@@ -27,18 +27,15 @@ import (
 var testRule = v1alpha1.IngressRule{
 	Hosts: []string{
 		"helloworld-go.default.svc.cluster.local",
-		"helloworld-go.default.example.com",
+		"helloworld-go.default.svc",
+		"helloworld-go.default",
 	},
 }
 
 func TestDomains(t *testing.T) {
-	internalDomains, externalDomains := Domains(testRule)
+	domains := Domains(testRule)
 
-	extExpected := []string{
-		"helloworld-go.default.example.com",
-		"helloworld-go.default.example.com:*",
-	}
-	intExpected := []string{
+	expected := []string{
 		"helloworld-go.default",
 		"helloworld-go.default:*",
 		"helloworld-go.default.svc",
@@ -46,12 +43,9 @@ func TestDomains(t *testing.T) {
 		"helloworld-go.default.svc.cluster.local",
 		"helloworld-go.default.svc.cluster.local:*",
 	}
-	sort.Strings(intExpected)
-	sort.Strings(externalDomains)
-	sort.Strings(internalDomains)
-	sort.Strings(extExpected)
-	assert.DeepEqual(t, externalDomains, extExpected)
-	assert.DeepEqual(t, internalDomains, intExpected)
+	sort.Strings(domains)
+	sort.Strings(expected)
+	assert.DeepEqual(t, domains, expected)
 }
 
 func TestRuleIsExternalWithVisibility(t *testing.T) {

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -46,7 +46,6 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/network"
 	knativeReconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
 )
@@ -138,7 +137,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	endpointsTracker := tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 
 	ingressTranslator := generator.NewIngressTranslator(
-		r.kubeClient, endpointsInformer.Lister(), network.GetClusterDomainName(), endpointsTracker, logger)
+		r.kubeClient, endpointsInformer.Lister(), endpointsTracker, logger)
 	r.ingressTranslator = &ingressTranslator
 
 	// Initialize the Envoy snapshot.


### PR DESCRIPTION
Since knative/serving#9100 Knative expands the cluster local domains in Ingress's spec.rules.hosts.
So Kourier does not needs to expand cluster local domains like:
`hello.myproject.svc.cluster.local` to `hello.myproject.svc`, `hello.myproject`.
This patch stops it.

This patch also refactors:
- to stop bringing cluster local domain but calls `GetClusterDomainName()` when necessary.
- to combine `internalDomain()` with `externalDomain()`.