### PR TITLE
Add MarkLoadBalancerNotRead when status manager fails to probe

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -54,10 +54,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ingress *v1alpha1.Ingres
 
 	r.ObserveKind(ctx, ingress)
 
-	if ready, err := r.statusManager.IsReady(context.TODO(), before); err != nil {
-		return err
-	} else if ready {
+	if ready, err := r.statusManager.IsReady(context.TODO(), before); err == nil && ready {
 		knative.MarkIngressReady(ingress)
+	} else {
+		ingress.Status.MarkLoadBalancerNotReady()
+		if err != nil {
+			return fmt.Errorf("failed to probe Ingress %s/%s: %w", ingress.GetNamespace(), ingress.GetName(), err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When updating an existing Ksvc, Kingress transits to weird status
`NewObservedGenFailure` like this:

```
status:
  conditions:
  - lastTransitionTime: "2020-08-26T02:58:01Z"
    status: "True"
    type: LoadBalancerReady
  - lastTransitionTime: "2020-08-26T02:33:48Z"
    status: "True"
    type: NetworkConfigured
  - lastTransitionTime: "2020-08-26T02:59:50Z"
    message: unsuccessfully observed a new generation
    reason: NewObservedGenFailure
    status: Unknown
    type: Ready
```

This patch adds `MarkLoadBalancerNotRead` when status manager fails to
probe. So the status transits to `Waiting for load balancer to be
ready` like this:

```
status:
  conditions:
  - lastTransitionTime: "2020-08-26T02:58:01Z"
    message: Waiting for load balancer to be ready
    reason: Uninitialized
    status: Unknown
    type: LoadBalancerReady
  - lastTransitionTime: "2020-08-26T02:33:48Z"
    status: "True"
    type: NetworkConfigured
  - lastTransitionTime: "2020-08-26T02:58:01Z"
    message: Waiting for load balancer to be ready
    reason: Uninitialized
    status: Unknown
    type: Ready
```

/cc @jmprusi @davidor 