### PR TITLE
Remove deprecated spec.visibility from KIngress

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -163,14 +163,9 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 		var virtualHost route.VirtualHost
 		if extAuthzEnabled {
 
-			visibility := ingress.Spec.Visibility
-			if visibility == "" { // Needed because visibility is optional
-				visibility = v1alpha1.IngressVisibilityClusterLocal
-			}
-
 			ContextExtensions := map[string]string{
 				"client":     "kourier",
-				"visibility": string(visibility),
+				"visibility": string(rule.Visibility),
 			}
 
 			ContextExtensions = mergeMapString(ContextExtensions, ingress.GetLabels())
@@ -179,7 +174,7 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 			virtualHost = envoy.NewVirtualHost(ingress.GetName(), domains, ruleRoute)
 		}
 
-		if knative.RuleIsExternal(rule, ingress.Spec.Visibility) {
+		if knative.RuleIsExternal(rule) {
 			res.externalVirtualHosts = append(res.externalVirtualHosts, &virtualHost)
 			// External should also be accessible internally
 			res.internalVirtualHosts = append(res.internalVirtualHosts, &virtualHost)

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -363,6 +363,7 @@ func createIngressWithTLS(hosts []string, secretName string, secretNamespace str
 			}},
 			Rules: []v1alpha1.IngressRule{
 				{
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{
 							{
@@ -387,7 +388,6 @@ func createIngressWithTLS(hosts []string, secretName string, secretNamespace str
 					},
 				},
 			},
-			Visibility: "",
 		},
 		Status: v1alpha1.IngressStatus{},
 	}

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -29,18 +29,8 @@ func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
 	internalDomain := domainForServiceName(config.InternalServiceName)
 	externalDomain := domainForServiceName(config.ExternalServiceName)
 
-	var domain string
-
-	if ingress.Spec.Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
-		domain = internalDomain
-	} else {
-		domain = externalDomain
-	}
-
 	ingress.Status.MarkLoadBalancerReady(
-		[]networkingv1alpha1.LoadBalancerIngressStatus{{
-			DomainInternal: domain,
-		}},
+		nil,
 		[]networkingv1alpha1.LoadBalancerIngressStatus{{
 			DomainInternal: externalDomain,
 		}},

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -39,15 +39,9 @@ func Domains(rule v1alpha1.IngressRule) []string {
 	return domains
 }
 
-func RuleIsExternal(rule v1alpha1.IngressRule, ingressVisibility v1alpha1.IngressVisibility) bool {
-	switch rule.Visibility {
-	case v1alpha1.IngressVisibilityExternalIP:
-		return true
-	case v1alpha1.IngressVisibilityClusterLocal:
+func RuleIsExternal(rule v1alpha1.IngressRule) bool {
+	if rule.Visibility == v1alpha1.IngressVisibilityClusterLocal {
 		return false
-	default:
-		// If the rule does not have a visibility set, use the one at the ingress level
-		// If there is not anything set, Knative defaults to "external"
-		return ingressVisibility != v1alpha1.IngressVisibilityClusterLocal
 	}
+	return true
 }

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -40,8 +40,5 @@ func Domains(rule v1alpha1.IngressRule) []string {
 }
 
 func RuleIsExternal(rule v1alpha1.IngressRule) bool {
-	if rule.Visibility == v1alpha1.IngressVisibilityClusterLocal {
-		return false
-	}
-	return true
+	return rule.Visibility == v1alpha1.IngressVisibilityExternalIP
 }

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -40,5 +40,8 @@ func Domains(rule v1alpha1.IngressRule) []string {
 }
 
 func RuleIsExternal(rule v1alpha1.IngressRule) bool {
-	return rule.Visibility == v1alpha1.IngressVisibilityExternalIP
+	if rule.Visibility == v1alpha1.IngressVisibilityClusterLocal {
+		return false
+	}
+	return true
 }

--- a/pkg/knative/ingress_rule_test.go
+++ b/pkg/knative/ingress_rule_test.go
@@ -56,24 +56,6 @@ func TestRuleIsExternalWithVisibility(t *testing.T) {
 		Visibility: v1alpha1.IngressVisibilityClusterLocal,
 	}
 
-	assert.Equal(t, RuleIsExternal(externalRule, ""), true)
-	assert.Equal(t, RuleIsExternal(internalRule, ""), false)
-}
-
-func TestRuleIsExternalWithIngressVisibility(t *testing.T) {
-	ruleWithoutVisibility := v1alpha1.IngressRule{Visibility: ""}
-
-	assert.Equal(
-		t, RuleIsExternal(ruleWithoutVisibility, v1alpha1.IngressVisibilityClusterLocal), false,
-	)
-	assert.Equal(
-		t, RuleIsExternal(ruleWithoutVisibility, v1alpha1.IngressVisibilityExternalIP), true,
-	)
-}
-
-func TestRuleIsExternalWithoutVisibility(t *testing.T) {
-	ruleWithoutVisibility := v1alpha1.IngressRule{Visibility: ""}
-
-	// Knative defaults to external, so it should return true
-	assert.Equal(t, RuleIsExternal(ruleWithoutVisibility, ""), true)
+	assert.Equal(t, RuleIsExternal(externalRule), true)
+	assert.Equal(t, RuleIsExternal(internalRule), false)
 }

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -76,7 +76,7 @@ func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, gatewayIp
 		domains := getDomains(rule)
 		scheme := "http"
 
-		if knative.RuleIsExternal(rule, ing.Spec.Visibility) {
+		if knative.RuleIsExternal(rule) {
 			target = status.ProbeTarget{
 				PodIPs: ips,
 			}

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -35,8 +35,7 @@ const (
 func createIngressSpec(name string, port int) v1alpha1.IngressSpec {
 	return v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
-			Hosts:      []string{name + domain},
-			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Hosts: []string{name + domain},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
 					Splits: []v1alpha1.IngressBackendSplit{{

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -47,6 +47,7 @@ func createIngressSpec(name string, port int) v1alpha1.IngressSpec {
 					}},
 				}},
 			},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 }


### PR DESCRIPTION
Since https://github.com/knative/networking/commit/f8dacf70c1e8a7daa7dd8847f42f3eb70fc5496a, Kingress deprecates `spec.visibility`.

This patch stops using spec.visibility and use spec.rules.visibility instead.