### PR TITLE
[WIP] Revert "Add MarkLoadBalancerNotRead when status manager fails to probe (#165)

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -54,13 +54,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ingress *v1alpha1.Ingres
 
 	r.ObserveKind(ctx, ingress)
 
-	if ready, err := r.statusManager.IsReady(context.TODO(), before); err == nil && ready {
+	if ready, err := r.statusManager.IsReady(context.TODO(), before); err != nil {
+		return err
+	} else if ready {
 		knative.MarkIngressReady(ingress)
-	} else {
-		ingress.Status.MarkLoadBalancerNotReady()
-		if err != nil {
-			return fmt.Errorf("failed to probe Ingress %s/%s: %w", ingress.GetNamespace(), ingress.GetName(), err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit f795c3bb5d4eb754b349469ae42b35bdc5c84bf5.

Current continuous build is unstable - https://testgrid.knative.dev/net-kourier#continuous
The ingress status does not become Ready due to `Waiting for load balancer to be ready`.
This patch tries to revert the suspicious commit.