### PR TITLE
Add Percent value in createIngressSpec for test

### DIFF
--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -44,6 +44,7 @@ func createIngressSpec(name string, port int) v1alpha1.IngressSpec {
 							ServiceNamespace: test.ServingNamespace,
 							ServicePort:      intstr.FromInt(port),
 						},
+						Percent: 100,
 					}},
 				}},
 			},


### PR DESCRIPTION
This patch adds `Percent` value in `createIngressSpec` for HA test.

In Kourier Gateway logs, the following message is printed many times.

```
kourier-system/3scale-kourier-gateway-848f48b8fd-m8qq6[kourier-gateway]: [2020-09-10 00:09:43.667][1][warning][config] [external/envoy/source/common/config/grpc_mux_subscription_impl.cc:82] gRPC config for type.googleapis.com/envoy.api.v2.RouteConfiguration rejected: Sum of weights in the weighted_cluster should add up to 100
```

This patch explicitly adds the value.

/cc @davidor @jmprusi @markusthoemmes 