### PR TITLE
Remove redundant log message

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -20,17 +20,14 @@ import (
 	"fmt"
 	"os"
 
-	"knative.dev/net-kourier/pkg/config"
-	"knative.dev/net-kourier/pkg/envoy"
-
-	"go.uber.org/zap"
-
-	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
+
+	"knative.dev/net-kourier/pkg/config"
+	"knative.dev/net-kourier/pkg/envoy"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/ingress"
 )
@@ -46,9 +43,7 @@ const (
 
 // For now, when updating the info for an ingress we delete it, and then
 // regenerate it. We can optimize this later.
-func UpdateInfoForIngress(caches *Caches, ing *v1alpha1.Ingress, kubeclient kubeclient.Interface, translator *IngressTranslator, logger *zap.SugaredLogger, extAuthzEnabled bool) error {
-	logger.Infof("Updating Knative Ingress %s/%s", ing.Name, ing.Namespace)
-
+func UpdateInfoForIngress(caches *Caches, ing *v1alpha1.Ingress, kubeclient kubeclient.Interface, translator *IngressTranslator, extAuthzEnabled bool) error {
 	// Adds a header with the ingress Hash and a random value header to force the config reload.
 	_, err := ingress.InsertProbe(ing)
 	if err != nil {

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -107,7 +107,7 @@ func (r *Reconciler) updateIngress(ctx context.Context, ingress *v1alpha1.Ingres
 	logger.Infof("Updating Ingress %s namespace: %s", ingress.Name, ingress.Namespace)
 
 	if err := generator.UpdateInfoForIngress(
-		r.caches, ingress, r.kubeClient, r.ingressTranslator, logger, r.extAuthz,
+		r.caches, ingress, r.kubeClient, r.ingressTranslator, r.extAuthz,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch removes redundant log message.

Currently these two messages
- `Updating Ingress kourier-control-h-a-mdpbzajj namespace: serving-tests`
- `Updating Knative Ingress kourier-control-h-a-mdpbzajj/serving-tests` 

are always printed "at the same time".

```
    kubelogs.go:197: I 00:20:03.919 3scale-kourier-control-9bfdb5c44-dtngc [ingress/ingress.go:107] [serving-tests/kourier-control-h-a-mdpbzajj] Updating Ingress kourier-control-h-a-mdpbzajj namespace: serving-tests
    kubelogs.go:197: I 00:20:03.919 3scale-kourier-control-9bfdb5c44-dtngc [generator/generator.go:50] [serving-tests/kourier-control-h-a-mdpbzajj] Updating Knative Ingress kourier-control-h-a-mdpbzajj/serving-tests
    kubelogs.go:197: I 00:20:04.319 3scale-kourier-control-9bfdb5c44-dtngc [controller/controller.go:522] [serving-tests/kourier-control-h-a-mdpbzajj] Reconcile succeeded. Time taken: 399.653784ms
    kubelogs.go:197: I 00:20:04.319 3scale-kourier-control-9bfdb5c44-dtngc [ingress/ingress.go:107] [serving-tests/kourier-control-h-a-mdpbzajj] Updating Ingress kourier-control-h-a-mdpbzajj namespace: serving-tests
    kubelogs.go:197: I 00:20:04.319 3scale-kourier-control-9bfdb5c44-dtngc [generator/generator.go:50] [serving-tests/kourier-control-h-a-mdpbzajj] Updating Knative Ingress kourier-control-h-a-mdpbzajj/serving-tests
    kubelogs.go:197: I 00:20:04.721 3scale-kourier-control-9bfdb5c44-dtngc [controller/controller.go:522] [serving-tests/kourier-control-h-a-mdpbzajj] Reconcile succeeded. Time taken: 402.199495ms
   ....
```

Please see the entire log in [build.log](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative-sandbox_net-kourier/179/pull-knative-sandbox-net-kourier-integration-tests/1303845061796040704)

/cc @davidor @jmprusi @markusthoemmes