### PR TITLE
Do not create EnvoyRoute if any of service/endpoint in the Ingress is not ready

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -109,7 +109,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 				endpoints, err := translator.endpointsLister.Endpoints(split.ServiceNamespace).Get(split.ServiceName)
 				if apierrors.IsNotFound(err) {
 					translator.logger.Warnf("Endpoints '%s/%s' not yet created", split.ServiceNamespace, split.ServiceName)
-					break
+					return nil, nil
 				} else if err != nil {
 					return nil, fmt.Errorf("failed to fetch endpoints '%s/%s': %w", split.ServiceNamespace, split.ServiceName, err)
 				}
@@ -117,7 +117,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 				service, err := translator.kubeclient.CoreV1().Services(split.ServiceNamespace).Get(ctx, split.ServiceName, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					translator.logger.Warnf("Service '%s/%s' not yet created", split.ServiceNamespace, split.ServiceName)
-					break
+					return nil, nil
 				} else if err != nil {
 					return nil, fmt.Errorf("failed to fetch service '%s/%s': %w", split.ServiceNamespace, split.ServiceName, err)
 				}

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -29,6 +29,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"go.uber.org/zap"
 	kubev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -106,12 +107,18 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 				}
 
 				endpoints, err := translator.endpointsLister.Endpoints(split.ServiceNamespace).Get(split.ServiceName)
-				if err != nil {
+				if apierrors.IsNotFound(err) {
+					translator.logger.Warnf("Endpoints '%s/%s' not yet created", split.ServiceNamespace, split.ServiceName)
+					return nil, nil
+				} else if err != nil {
 					return nil, fmt.Errorf("failed to fetch endpoints '%s/%s': %w", split.ServiceNamespace, split.ServiceName, err)
 				}
 
 				service, err := translator.kubeclient.CoreV1().Services(split.ServiceNamespace).Get(ctx, split.ServiceName, metav1.GetOptions{})
-				if err != nil {
+				if apierrors.IsNotFound(err) {
+					translator.logger.Warnf("Service '%s/%s' not yet created", split.ServiceNamespace, split.ServiceName)
+					return nil, nil
+				} else if err != nil {
 					return nil, fmt.Errorf("failed to fetch service '%s/%s': %w", split.ServiceNamespace, split.ServiceName, err)
 				}
 


### PR DESCRIPTION
When endpoint or service was not created, current code does not stop
creating virtualHost but just break the loop.
Due to this, it is possible to create a EnvoyRoute without 100%
weighted_cluster.

For example, when we have the following ingress, net-kourier creates 70% Route if `hello-example-1`
svc is found but `hello-example-2` svc is not found.

```
spec:
  rules:
  - hosts:
    - hello-example.default.18.138.21.218.xip.io
    http:
      paths:
      - splits:
        - appendHeaders:
            Knative-Serving-Namespace: default
            Knative-Serving-Revision: hello-example-1
          percent: 70
          serviceName: hello-example-1
          serviceNamespace: default
          servicePort: 80
        - appendHeaders:
            Knative-Serving-Namespace: default
            Knative-Serving-Revision: hello-example-2
          percent: 30
          serviceName: hello-example-2
          serviceNamespace: default
          servicePort: 80
```

To fix it, this patch returns nil if any of service/endpoint in the
Ingress is not ready.