### PR TITLE
Enable alpha test but skips host-rewrite test

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,7 +23,7 @@ failed=0
 
 go_test_e2e -timeout=20m -parallel=12 \
   ./test/conformance \
-  --enable-beta \
+  --enable-beta --enable-alpha --skip-tests="host-rewrite" \
   --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Give the controller time to sync with the rest of the system components.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,7 +23,7 @@ failed=0
 
 go_test_e2e -timeout=20m -parallel=12 \
   ./test/conformance \
-  --enable-beta --enable-alpha --skip-tests="host-rewrite" \
+  --enable-alpha --enable-beta --skip-tests="host-rewrite" \
   --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Give the controller time to sync with the rest of the system components.


### PR DESCRIPTION
This patch enables alpha test but skips "host-rewrite" until https://github.com/knative-sandbox/net-kourier/issues/159 was solved.

/cc @davidor @jmprusi
