### PR TITLE
Supply metrics domain via environment

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -17,8 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"knative.dev/net-kourier/pkg/config"
 	kourierIngressController "knative.dev/net-kourier/pkg/reconciler/ingress"
 
@@ -27,8 +25,5 @@ import (
 )
 
 func main() {
-	// TODO: make this configurable
-	_ = os.Setenv("METRICS_DOMAIN", "knative.dev/samples")
-
 	sharedmain.Main(config.ControllerName, kourierIngressController.NewController)
 }

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -115,6 +115,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: METRICS_DOMAIN
+              value: "knative.dev/samples"
             - name: KOURIER_GATEWAY_NAMESPACE
               value: "kourier-system"
           ports:


### PR DESCRIPTION
As per title. This aligns Kourier with other Knative componentry.