### PR TITLE
Set timeout explicitly to 0

### DIFF
--- a/pkg/envoy/route.go
+++ b/pkg/envoy/route.go
@@ -18,15 +18,19 @@ package envoy
 
 import (
 	"net/http"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func NewRoute(name string,
 	headersMatch []*route.HeaderMatcher,
 	path string,
 	wrs []*route.WeightedCluster_ClusterWeight,
+	routeTimeout time.Duration,
 	headers map[string]string) *route.Route {
 
 	return &route.Route{
@@ -43,6 +47,7 @@ func NewRoute(name string,
 					Clusters: wrs,
 				},
 			},
+			Timeout: ptypes.DurationProto(routeTimeout),
 			UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
 				UpgradeType: "websocket",
 				Enabled:     &wrappers.BoolValue{Value: true},

--- a/pkg/envoy/route_test.go
+++ b/pkg/envoy/route_test.go
@@ -40,7 +40,7 @@ func TestNewRouteHeaderMatch(t *testing.T) {
 	AppendHeaders := map[string]string{}
 	var wrs []*envoy_api_v2_route.WeightedCluster_ClusterWeight
 
-	r := NewRoute(name, headerMatch, path, wrs, AppendHeaders)
+	r := NewRoute(name, headerMatch, path, wrs, 0, AppendHeaders)
 	assert.Equal(t, r.Match.Headers[0].Name, "myHeader")
 	assert.Equal(t, r.Match.Headers[0].GetExactMatch(), "strict")
 

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -223,13 +223,8 @@ func createRouteForRevision(ingressName string, ingressNamespace string, httpPat
 		path = httpPath.Path
 	}
 
-	var routeTimeout time.Duration
-	if httpPath.Timeout != nil {
-		routeTimeout = httpPath.Timeout.Duration
-	}
-
 	return envoy.NewRoute(
-		routeName, matchHeadersFromHTTPPath(httpPath), path, wrs, routeTimeout, httpPath.AppendHeaders,
+		routeName, matchHeadersFromHTTPPath(httpPath), path, wrs, 0, httpPath.AppendHeaders,
 	)
 }
 

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -223,8 +223,13 @@ func createRouteForRevision(ingressName string, ingressNamespace string, httpPat
 		path = httpPath.Path
 	}
 
+	var routeTimeout time.Duration
+	if httpPath.Timeout != nil {
+		routeTimeout = httpPath.Timeout.Duration
+	}
+
 	return envoy.NewRoute(
-		routeName, matchHeadersFromHTTPPath(httpPath), path, wrs, httpPath.AppendHeaders,
+		routeName, matchHeadersFromHTTPPath(httpPath), path, wrs, routeTimeout, httpPath.AppendHeaders,
 	)
 }
 

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -17,6 +17,8 @@ limitations under the License.
 package generator
 
 import (
+	"time"
+
 	"knative.dev/net-kourier/pkg/config"
 	"knative.dev/net-kourier/pkg/envoy"
 
@@ -37,7 +39,7 @@ func readyRoute() *route.Route {
 	cluster := envoy.NewWeightedCluster("service_stats", 100, map[string]string{})
 	var wrs []*route.WeightedCluster_ClusterWeight
 	wrs = append(wrs, cluster)
-	route := envoy.NewRoute("gateway_ready", nil, "/ready", wrs, map[string]string{})
+	route := envoy.NewRoute("gateway_ready", nil, "/ready", wrs, 1*time.Second, map[string]string{})
 
 	return route
 }


### PR DESCRIPTION
This patch reverts https://github.com/knative-sandbox/net-kourier/pull/250 and then explicitly sets the timeout to 0 (infinite).
It also reverts the timeout of health check access `readyRoute()` to `1s`.

/cc @jmprusi @davidor @markusthoemmes 