### PR TITLE
Add explicit security contexts

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -62,6 +62,13 @@ spec:
             - name: https-external
               containerPort: 8443
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - all
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config
@@ -123,6 +130,13 @@ spec:
           - name: http2-xds
             containerPort: 18000
             protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
       restartPolicy: Always
       serviceAccountName: 3scale-kourier
 ---


### PR DESCRIPTION
This adds the narrowest security contexts possible.

Sadly, the envoy image wants to run as root and needs write access to the filesystem. I'll file an issue to address that, it seems somewhat unnecessary.