### PR TITLE
Drop imagePullPolicy: Always as it prevents dev workflows

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -50,7 +50,6 @@ spec:
           command:
             - /usr/local/bin/envoy
           image: docker.io/maistra/proxyv2-ubi8:1.1.5
-          imagePullPolicy: Always
           name: kourier-gateway
           ports:
             - name: http2-external
@@ -104,7 +103,6 @@ spec:
     spec:
       containers:
         - image: ko://knative.dev/net-kourier/cmd/kourier
-          imagePullPolicy: Always
           name: kourier-control
           env:
             - name: CERTS_SECRET_NAMESPACE


### PR DESCRIPTION
This makes local `ko` based workflows impossible and seems unnecessary.