### PR TITLE
Optimize cache warmup on startup

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -45,43 +45,17 @@ type Caches struct {
 	listeners           []*v2.Listener
 	statusVirtualHost   *route.VirtualHost
 	logger              *zap.SugaredLogger
-	ingressesToSync     map[string]struct{}
-	synced              chan struct{}
 }
 
-func NewCaches(ctx context.Context, logger *zap.SugaredLogger, kubernetesClient kubeclient.Interface, extAuthz bool, ingressesToSync []*v1alpha1.Ingress) (*Caches, error) {
+func NewCaches(ctx context.Context, logger *zap.SugaredLogger, kubernetesClient kubeclient.Interface, extAuthz bool) (*Caches, error) {
 	c := &Caches{
 		ingresses:           make(map[string]*v1alpha1.Ingress),
 		translatedIngresses: make(map[string]*translatedIngress),
 		clusters:            newClustersCache(logger.Named("cluster-cache")),
 		clustersToIngress:   make(map[string][]string),
 		logger:              logger,
-		synced:              make(chan struct{}),
 	}
-	err := c.initConfig(ctx, kubernetesClient, extAuthz)
-
-	if len(ingressesToSync) == 0 {
-		// If ingressesToSync is empty, we can just close the "synced" channel now as we don't need to warm anything.
-		close(c.synced)
-	} else {
-		// Create our list of IngressesToSync from the array of ingresses, using the mapKey func.
-		c.ingressesToSync = make(map[string]struct{}, len(ingressesToSync))
-		for _, ingress := range ingressesToSync {
-			logger.Infof("added ingress to cache warmup %s/%s", ingress.Namespace, ingress.Name)
-			c.ingressesToSync[mapKey(ingress.Name, ingress.Namespace)] = struct{}{}
-		}
-		logger.Infof("total of %d ingresses to warm", len(c.ingressesToSync))
-	}
-
-	return c, err
-}
-
-func (caches *Caches) WaitForSync() <-chan struct{} {
-	return caches.synced
-}
-
-func (caches *Caches) hasSynced() bool {
-	return len(caches.ingressesToSync) == 0
+	return c, c.initConfig(ctx, kubernetesClient, extAuthz)
 }
 
 func (caches *Caches) UpdateIngress(ctx context.Context, ingress *v1alpha1.Ingress, ingressTranslation *translatedIngress, kubeclient kubeclient.Interface) error {
@@ -149,9 +123,6 @@ func (caches *Caches) addTranslatedIngress(ingress *v1alpha1.Ingress, translated
 	key := mapKey(ingress.Name, ingress.Namespace)
 	caches.ingresses[key] = ingress
 	caches.translatedIngresses[key] = translatedIngress
-
-	// Remove the Ingress from the Sync list as it has been warmed.
-	caches.deleteFromSyncList(ingress.Name, ingress.Namespace)
 
 	for _, cluster := range translatedIngress.clusters {
 		caches.addClusterForIngress(cluster, ingress.Name, ingress.Namespace)
@@ -232,17 +203,6 @@ func (caches *Caches) ToEnvoySnapshot() (cache.Snapshot, error) {
 	), nil
 }
 
-func (caches *Caches) deleteFromSyncList(ingressName, ingressNamespace string) {
-	// If caches are not synced, we try to delete the ingress from the IngressesToSync list
-	if !caches.hasSynced() {
-		delete(caches.ingressesToSync, mapKey(ingressName, ingressNamespace))
-		// Now let's see if after the delete we are in Sync and cwe can close the channel.
-		if caches.hasSynced() {
-			close(caches.synced)
-		}
-	}
-}
-
 // Note: changes the snapshot version of the caches object
 // Notice that the clusters are not deleted. That's handled with the expiration
 // time set in the "ClustersCache" struct.
@@ -250,9 +210,6 @@ func (caches *Caches) DeleteIngressInfo(ctx context.Context, ingressName string,
 	kubeclient kubeclient.Interface) error {
 	caches.mu.Lock()
 	defer caches.mu.Unlock()
-
-	// Remove the Ingress from the Sync list as there's no point to wait for it to be synced.
-	caches.deleteFromSyncList(ingressName, ingressNamespace)
 
 	caches.deleteTranslatedIngress(ingressName, ingressNamespace)
 	return caches.setListeners(ctx, kubeclient)

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -41,7 +41,7 @@ func TestDeleteIngressInfo(t *testing.T) {
 	kubeClient := fake.Clientset{}
 	ctx := context.Background()
 
-	caches, err := NewCaches(ctx, logger, &kubeClient, false, nil)
+	caches, err := NewCaches(ctx, logger, &kubeClient, false)
 	if err != nil {
 		t.Fail()
 	}
@@ -102,7 +102,7 @@ func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 	kubeClient := fake.Clientset{}
 	ctx := context.Background()
 
-	caches, err := NewCaches(ctx, logger, &kubeClient, false, nil)
+	caches, err := NewCaches(ctx, logger, &kubeClient, false)
 	if err != nil {
 		t.Fail()
 	}
@@ -196,7 +196,7 @@ func TestValidateIngress(t *testing.T) {
 	kubeClient := fake.Clientset{}
 	ctx := context.Background()
 
-	caches, err := NewCaches(ctx, logger, &kubeClient, false, nil)
+	caches, err := NewCaches(ctx, logger, &kubeClient, false)
 	if err != nil {
 		t.Fail()
 	}
@@ -235,78 +235,4 @@ func getVHostsNames(routeConfigs []v2.RouteConfiguration) []string {
 	}
 
 	return res
-}
-
-func TestCacheWithWarmingWithoutIngressesToSync(t *testing.T) {
-	logger := zap.S()
-	kubeClient := fake.Clientset{}
-	ctx := context.Background()
-
-	var ingressesToSync []*v1alpha1.Ingress
-	caches, err := NewCaches(ctx, logger, &kubeClient, false, ingressesToSync)
-	if err != nil {
-		t.Fail()
-	}
-
-	// If caches are not synced, let's fail as this should return false.
-	if !caches.hasSynced() {
-		t.Fail()
-	}
-
-	// WaitForSync channel should be closed.
-	select {
-	case <-caches.WaitForSync():
-		return
-	default:
-		t.Fail()
-	}
-}
-
-func TestCacheWithWarmingWithIngressesToSync(t *testing.T) {
-	logger := zap.S()
-	kubeClient := fake.Clientset{}
-	ctx := context.Background()
-
-	ingressesToSync := []*v1alpha1.Ingress{
-		{
-			TypeMeta:   metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "namespace1"},
-			Spec:       v1alpha1.IngressSpec{},
-			Status:     v1alpha1.IngressStatus{},
-		},
-	}
-	caches, err := NewCaches(ctx, logger, &kubeClient, false, ingressesToSync)
-	if err != nil {
-		t.Fail()
-	}
-
-	// If caches are synced, let's fail, as this should return false.
-	if caches.hasSynced() {
-		t.Fail()
-	}
-
-	// WaitForSync should still be open.
-	select {
-	case <-caches.WaitForSync():
-		t.Fail()
-	default:
-		// This means the channel has no data and it's still open, this is good, let's continue.
-		break
-	}
-
-	caches.deleteFromSyncList("test1", "namespace1")
-
-	// If caches are not synced, let's fail as this should return false.
-	if !caches.hasSynced() {
-		t.Fail()
-	}
-
-	// Let's check for the sync channel to be closed.
-	select {
-	case <-caches.WaitForSync():
-		return
-	default:
-		// Let's fail as the channel has not been closed.
-		t.Fail()
-	}
 }


### PR DESCRIPTION
This makes cache warmup at startup simpler (and most likely faster too):
Instead of relying on the global resync to do its thing (which can be very slow, especially because of our two-lane queues), this runs all the ingresses through the reconciler without queueing them and before launching the config server. Having this seeded config is necessary to start it anyway, so we might as well block startup on it completely.