### PR TITLE
Update codecov config to not warn on existing coverage

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,5 +1,21 @@
+coverage:
+  # Commit status https://docs.codecov.io/docs/commit-status are used
+  # to block PR based on coverage threshold.
+  status:
+    project:
+      default:
+        target: 80
+        threshold: 1%
+    patch:
+      # Disable the coverage threshold of the patch, so that PRs are
+      # only failing because of overall project coverage threshold.
+      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
+      default: false
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
+  - "**/*.pb.go" # Ignore proto-generated files.
+  - "hack"
   - "pkg/client"
+  - "test"
   - "third_party"
   - "vendor"


### PR DESCRIPTION
This makes the config equal with serving's and thus is less annoying.