### PR TITLE
Rewrite local setup to use kind instead of k3d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ test: test-unit test-integration test-serving-conformance ## Runs all the tests
 
 test-unit: ## Runs unit tests
 	mkdir -p "$(PROJECT_PATH)/tests_output"
-	k3d kubeconfig merge kourier-integration --switch-context
 	go test -mod vendor -race $(shell go list ./... | grep -v kourier/test) -coverprofile="$(PROJECT_PATH)/tests_output/unit.cov"
 
 test-integration: local-setup ## Runs integration tests
 	go test -mod vendor -race test/*.go
+
 test-serving-conformance: local-setup ## Runs Knative Serving conformance tests
-	k3d kubeconfig merge kourier-integration --switch-context
+	kind export kubeconfig --name kourier-integration
 	ko apply -f test/config/100-test-namespace.yaml
 	go test -v -tags=e2e ./vendor/knative.dev/serving/test/conformance/ingress/... --ingressClass="kourier.ingress.networking.knative.dev"
 

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -1,62 +1,34 @@
 #!/bin/bash
 
-source $(dirname $0)/../test/e2e-common.sh
-
 set -euo pipefail
-IFS=$'\n\t'
 
 KNATIVE_NAMESPACE=knative-serving
 KOURIER_GATEWAY_NAMESPACE=kourier-system
 KOURIER_CONTROL_NAMESPACE=${KNATIVE_NAMESPACE}
-if ! command -v k3d >/dev/null; then
-  echo "k3d binary not in path, install with: curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash"
-  exit 1
-fi
 
-tag="test_$(git rev-parse --abbrev-ref HEAD)"
+export KIND_CLUSTER_NAME="kourier-integration"
+kind delete cluster
+kind create cluster
 
-# In CircleCI, PR branches that come from forks have the format "pull/n", where
-# n is the PR number. "/" is not accepted in docker tags, so we need to replace
-# it.
-tag=$(echo "$tag" | tr / -)
-
-k3d cluster delete kourier-integration || true
-k3d cluster create --wait --no-lb --k3s-server-arg '--no-deploy=traefik' kourier-integration
-
-# Builds and imports the kourier and gateway images from docker into the k8s cluster
-docker build -t 3scale-kourier:"$tag" ./
-docker build -f ./utils/extauthz_test_image/Dockerfile -t test_externalauthz:test ./utils/extauthz_test_image/
-k3d image import 3scale-kourier:"$tag" -c 'kourier-integration'
-k3d image import test_externalauthz:test -c 'kourier-integration'
-
-KNATIVE_VERSION=v0.17.0
-# Deploys kourier and patches it.
+echo "Deploying Knative Serving"
+KNATIVE_VERSION=v0.18.0
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
-kubectl apply -f deploy/kourier-knative.yaml
-kubectl patch deployment 3scale-kourier-control -n ${KNATIVE_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
 kubectl patch configmap/config-domain -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
-retries=0
-while [[ $(kubectl get pods -n ${KOURIER_CONTROL_NAMESPACE} -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
-  echo "Waiting for kourier control pod to be ready "
-  sleep 10
-  if [ $retries -ge 7 ]; then
-    echo "timedout waiting for kourier control pod"
-    exit 1
-  fi
-  retries=$((retries + 1))
+
+echo "Deploying Kourier"
+KO_DOCKER_REPO=kind.local ko apply -Rf deploy/kourier-knative.yaml
+
+echo "Wait for all deployments to be up"
+for d in $(kubectl -n ${KOURIER_CONTROL_NAMESPACE} get deploy -oname)
+do
+  kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available "$d"
 done
 
-retries=0
-while [[ $(kubectl get pods -n ${KOURIER_GATEWAY_NAMESPACE} -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
-  echo "Waiting for kourier gateway pod to be ready "
-  sleep 10
-  if [ $retries -ge 10 ]; then
-    echo "timedout waiting for kourier gateway pod"
-    exit 1
-  fi
-  retries=$((retries + 1))
+for d in $(kubectl -n ${KOURIER_GATEWAY_NAMESPACE} get deploy -oname)
+do
+  kubectl -n "${KOURIER_GATEWAY_NAMESPACE}" wait --timeout=300s --for=condition=Available "$d"
 done
 
 # shellcheck disable=SC2046


### PR DESCRIPTION
`kind` is widely supported throughout Knative, so Kourier is currently a bit of an oddball. One of the biggest wins is `ko` support, so no `docker` builds are necessary :tada: 