### PR TITLE
Rework logging to use more contextualized logging and avoid passing loggers around

### DIFF
--- a/pkg/envoy/callbacks.go
+++ b/pkg/envoy/callbacks.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"go.uber.org/zap"
 )
 
 // Returning an error will end processing and close the stream. OnStreamClosed will still be called.
@@ -36,11 +35,9 @@ func (cb *Callbacks) OnStreamClosed(id int64) {
 // OnStreamRequest is called once a request is received on a stream.
 // Returning an error will end processing and close the stream. OnStreamClosed will still be called.
 func (cb *Callbacks) OnStreamRequest(_ int64, req *v2.DiscoveryRequest) error {
-
 	if req.ErrorDetail != nil {
-		cb.Logger.Infof("OnStreamRequest error pushing snapshot to gateway: code: %v message %s", req.ErrorDetail.Code, req.ErrorDetail.Message)
 		if cb.OnError != nil {
-			cb.OnError()
+			cb.OnError(req)
 		}
 		return fmt.Errorf("OnStreamRequest error pushing snapshot to gateway %v", req.ErrorDetail.Message)
 	}
@@ -62,6 +59,5 @@ func (cb *Callbacks) OnFetchResponse(req *v2.DiscoveryRequest, resp *v2.Discover
 }
 
 type Callbacks struct {
-	Logger  *zap.SugaredLogger
-	OnError func()
+	OnError func(*v2.DiscoveryRequest)
 }

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -35,7 +35,6 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"knative.dev/net-kourier/pkg/envoy"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
-	logtest "knative.dev/pkg/logging/testing"
 	pkgtest "knative.dev/pkg/reconciler/testing"
 )
 
@@ -120,7 +119,7 @@ func TestTrafficSplits(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{})
 
 	ingressTranslation, err := ingressTranslator.translateIngress(ctx, &ingress, false)
 	if err != nil {
@@ -199,7 +198,7 @@ func TestIngressVisibility(t *testing.T) {
 			}
 
 			ingressTranslator := NewIngressTranslator(
-				kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+				kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{})
 
 			translatedIngress, err := ingressTranslator.translateIngress(ctx, ingress, false)
 			if err != nil {
@@ -253,7 +252,7 @@ func TestIngressWithTLS(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{})
 
 	translatedIngress, err := ingressTranslator.translateIngress(ctx, ingress, false)
 	if err != nil {
@@ -287,11 +286,11 @@ func TestReturnsErrorWhenTLSSecretDoesNotExist(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{}, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), newMockedServiceLister(), &pkgtest.FakeTracker{})
 
 	_, err := ingressTranslator.translateIngress(ctx, ingress, false)
 
-	assert.Error(t, err, fmt.Sprintf("secrets \"%s\" not found", tlsSecretName))
+	assert.Error(t, err, fmt.Sprintf("failed to get sniMatch: secrets \"%s\" not found", tlsSecretName))
 }
 
 func newMockedEndpointsLister() corev1listers.EndpointsLister {

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -137,8 +137,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	tracker := tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 
 	ingressTranslator := generator.NewIngressTranslator(
-		r.kubeClient, endpointsInformer.Lister(), serviceInformer.Lister(),
-		tracker, logger)
+		r.kubeClient, endpointsInformer.Lister(), serviceInformer.Lister(), tracker)
 	r.ingressTranslator = &ingressTranslator
 
 	// Initialize the Envoy snapshot.


### PR DESCRIPTION
As per title, this is a first stab at more principled logging. The context of a reconcile has a logger that is already contextualized, so we can use that instead.