### PR TITLE
Replace panics with proper calls to a logger

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -73,7 +73,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	// know when it has been synced.
 	ingressesToSync, err := getReadyIngresses(ctx, knativeClient.NetworkingV1alpha1())
 	if err != nil {
-		logger.Fatalw("Failed to get intial set of ready ingresses", zap.Error(err))
+		logger.Fatalw("Failed to get initial set of ready ingresses", zap.Error(err))
 	}
 
 	// Create a new Cache, with the Readiness endpoint enabled, and the list of current Ingresses.

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -58,26 +58,28 @@ const (
 )
 
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	logger := logging.FromContext(ctx)
+
 	kubernetesClient := kubeclient.Get(ctx)
 	knativeClient := knativeclient.Get(ctx)
-	logger := logging.FromContext(ctx)
 	ingressInformer := ingressinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
 	podInformer := podinformer.Get(ctx)
+
 	extAuthZConfig := envoy.GetExternalAuthzConfig()
 
 	// Get the current list of ingresses that are ready, and pass it to the cache so we can
 	// know when it has been synced.
 	ingressesToSync, err := getReadyIngresses(ctx, knativeClient.NetworkingV1alpha1())
 	if err != nil {
-		panic(err)
+		logger.Fatalw("Failed to get intial set of ready ingresses", zap.Error(err))
 	}
 
 	// Create a new Cache, with the Readiness endpoint enabled, and the list of current Ingresses.
 	caches, err := generator.NewCaches(ctx, logger.Named("caches"), kubernetesClient, extAuthZConfig.Enabled, ingressesToSync)
 	if err != nil {
-		panic(err)
+		logger.Fatalw("Failed create new caches", zap.Error(err))
 	}
 
 	r := &Reconciler{

--- a/test/extauthz/integration_test.go
+++ b/test/extauthz/integration_test.go
@@ -67,7 +67,7 @@ func ExtAuthzScenario(t *testing.T) {
 
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	servingNetworkClient, err := KnativeServingNetworkClient(kubeconfig)


### PR DESCRIPTION
As per title.

ExtAuthZ still has some, but replacing them is a bit of a bigger operation, so I'll do that separately.