### PR TITLE
Refactor ExtAuthz config as a global config that's only read once

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	go.uber.org/zap v1.16.0
 	google.golang.org/grpc v1.33.1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,11 +32,5 @@ const (
 
 	GatewayNamespaceEnv = "KOURIER_GATEWAY_NAMESPACE"
 
-	ExtAuthzHostEnv          = "KOURIER_EXTAUTHZ_HOST"
-	ExtAuthzFailureModeEnv   = "KOURIER_EXTAUTHZ_FAILUREMODEALLOW"
-	ExtAuthzMaxRequestsBytes = "KOURIER_EXTAUTHZ_MAXREQUESTBYTES"
-	ExtAuthzTimeout          = "KOURIER_EXTAUTHZ_TIMEOUT"
-	ExternalAuthzCluster     = "extAuthz"
-
 	KourierIngressClassName = "kourier.ingress.networking.knative.dev"
 )

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -34,6 +34,8 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
+const extAuthzClusterName = "extAuthz"
+
 var ExternalAuthz = &ExternalAuthzConfig{
 	Enabled: false,
 }
@@ -75,19 +77,19 @@ func init() {
 	ExternalAuthz = &ExternalAuthzConfig{
 		Enabled:    true,
 		Cluster:    extAuthzCluster(host, uint32(port)),
-		HTTPFilter: externalAuthZFilter(ExternalAuthzCluster, timeout, env.FailureModeAllow, env.MaxRequestBytes),
+		HTTPFilter: externalAuthZFilter(extAuthzClusterName, timeout, env.FailureModeAllow, env.MaxRequestBytes),
 	}
 }
 
 func extAuthzCluster(host string, port uint32) *v2.Cluster {
 	return &v2.Cluster{
-		Name: ExternalAuthzCluster,
+		Name: extAuthzClusterName,
 		ClusterDiscoveryType: &v2.Cluster_Type{
 			Type: v2.Cluster_STRICT_DNS,
 		},
 		ConnectTimeout: ptypes.DurationProto(5 * time.Second),
 		LoadAssignment: &v2.ClusterLoadAssignment{
-			ClusterName: ExternalAuthzCluster,
+			ClusterName: extAuthzClusterName,
 			Endpoints: []*endpoint.LocalityLbEndpoints{{
 				LbEndpoints: []*endpoint.LbEndpoint{&endpoint.LbEndpoint{
 					HostIdentifier: &endpoint.LbEndpoint_Endpoint{

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -34,7 +34,9 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-var ExternalAuthz = &ExternalAuthzConfig{}
+var ExternalAuthz = &ExternalAuthzConfig{
+	Enabled: false,
+}
 
 type ExternalAuthzConfig struct {
 	Enabled    bool

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -91,7 +91,7 @@ func extAuthzCluster(host string, port uint32) *v2.Cluster {
 		LoadAssignment: &v2.ClusterLoadAssignment{
 			ClusterName: extAuthzClusterName,
 			Endpoints: []*endpoint.LocalityLbEndpoints{{
-				LbEndpoints: []*endpoint.LbEndpoint{&endpoint.LbEndpoint{
+				LbEndpoints: []*endpoint.LbEndpoint{{
 					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
 						Endpoint: &endpoint.Endpoint{
 							Address: &core.Address{

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -24,7 +24,6 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
@@ -117,14 +116,14 @@ func extAuthzCluster(host string, port uint32) *v2.Cluster {
 func externalAuthZFilter(clusterName string, timeout time.Duration, failureModeAllow bool, maxRequestBytes uint32) *httpconnectionmanagerv2.HttpFilter {
 	extAuthConfig := &extAuthService.ExtAuthz{
 		Services: &extAuthService.ExtAuthz_GrpcService{
-			GrpcService: &envoy_api_v2_core.GrpcService{
-				TargetSpecifier: &envoy_api_v2_core.GrpcService_EnvoyGrpc_{
-					EnvoyGrpc: &envoy_api_v2_core.GrpcService_EnvoyGrpc{
+			GrpcService: &core.GrpcService{
+				TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
 						ClusterName: clusterName,
 					},
 				},
 				Timeout: ptypes.DurationProto(timeout),
-				InitialMetadata: []*envoy_api_v2_core.HeaderValue{{
+				InitialMetadata: []*core.HeaderValue{{
 					Key:   "client",
 					Value: "kourier",
 				}},

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -35,6 +35,8 @@ import (
 
 const maxRequestBytesDefault = 8192
 
+var ExternalAuthz *ExternalAuthzConfig
+
 type ExternalAuthzConfig struct {
 	Enabled          bool
 	Host             string
@@ -46,8 +48,8 @@ type ExternalAuthzConfig struct {
 	HTTPFilter       *httpconnectionmanagerv2.HttpFilter
 }
 
-func GetExternalAuthzConfig() ExternalAuthzConfig {
-	res := ExternalAuthzConfig{}
+func init() {
+	res := &ExternalAuthzConfig{}
 	var err error
 
 	if externalAuthzURI, ok := os.LookupEnv(ExtAuthzHostEnv); ok {
@@ -93,7 +95,7 @@ func GetExternalAuthzConfig() ExternalAuthzConfig {
 	res.Cluster = extAuthzCluster(res.Host, uint32(res.Port))
 	res.HTTPFilter = externalAuthZFilter(ExternalAuthzCluster, res.Timeout, res.FailureModeAllow, uint32(res.MaxRequestBytes))
 
-	return res
+	ExternalAuthz = res
 }
 
 func extAuthzCluster(host string, port uint32) *v2.Cluster {

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package envoy
+package config
 
 import (
 	"net"
@@ -31,7 +31,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
-	"knative.dev/net-kourier/pkg/config"
 )
 
 const maxRequestBytesDefault = 8192
@@ -51,7 +50,7 @@ func GetExternalAuthzConfig() ExternalAuthzConfig {
 	res := ExternalAuthzConfig{}
 	var err error
 
-	if externalAuthzURI, ok := os.LookupEnv(config.ExtAuthzHostEnv); ok {
+	if externalAuthzURI, ok := os.LookupEnv(ExtAuthzHostEnv); ok {
 		var strPort string
 		res.Host, strPort, err = net.SplitHostPort(externalAuthzURI)
 		if err != nil {
@@ -64,14 +63,14 @@ func GetExternalAuthzConfig() ExternalAuthzConfig {
 		res.Enabled = true
 	}
 
-	if failureMode, ok := os.LookupEnv(config.ExtAuthzFailureModeEnv); ok {
+	if failureMode, ok := os.LookupEnv(ExtAuthzFailureModeEnv); ok {
 		res.FailureModeAllow, err = strconv.ParseBool(failureMode)
 		if err != nil {
 			panic(err)
 		}
 	}
 
-	if maxRequestBytes, ok := os.LookupEnv(config.ExtAuthzMaxRequestsBytes); ok {
+	if maxRequestBytes, ok := os.LookupEnv(ExtAuthzMaxRequestsBytes); ok {
 		res.MaxRequestBytes, err = strconv.Atoi(maxRequestBytes)
 		if err != nil {
 			panic(err)
@@ -80,7 +79,7 @@ func GetExternalAuthzConfig() ExternalAuthzConfig {
 		res.MaxRequestBytes = maxRequestBytesDefault
 	}
 
-	if strTimeout, ok := os.LookupEnv(config.ExtAuthzTimeout); ok {
+	if strTimeout, ok := os.LookupEnv(ExtAuthzTimeout); ok {
 		millis, err := strconv.Atoi(strTimeout)
 		if err != nil {
 			panic(err)
@@ -99,13 +98,13 @@ func GetExternalAuthzConfig() ExternalAuthzConfig {
 
 func (e *ExternalAuthzConfig) extAuthzCluster() *v2.Cluster {
 	return &v2.Cluster{
-		Name: config.ExternalAuthzCluster,
+		Name: ExternalAuthzCluster,
 		ClusterDiscoveryType: &v2.Cluster_Type{
 			Type: v2.Cluster_STRICT_DNS,
 		},
 		ConnectTimeout: ptypes.DurationProto(5 * time.Second),
 		LoadAssignment: &v2.ClusterLoadAssignment{
-			ClusterName: config.ExternalAuthzCluster,
+			ClusterName: ExternalAuthzCluster,
 			Endpoints: []*endpoint.LocalityLbEndpoints{{
 				LbEndpoints: []*endpoint.LbEndpoint{&endpoint.LbEndpoint{
 					HostIdentifier: &endpoint.LbEndpoint_Endpoint{

--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
+	"knative.dev/net-kourier/pkg/config"
 )
 
 func NewHTTPConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionmanagerv2.HttpConnectionManager {
@@ -33,7 +34,7 @@ func NewHTTPConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 	var filters []*httpconnectionmanagerv2.HttpFilter
 
 	// Get the extAuthzConf from envs vars.
-	extAuthzConf := GetExternalAuthzConfig()
+	extAuthzConf := config.GetExternalAuthzConfig()
 
 	if extAuthzConf.Enabled {
 		filters = append(filters, extAuthzConf.HTTPFilter)

--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -33,11 +33,8 @@ func NewHTTPConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 
 	var filters []*httpconnectionmanagerv2.HttpFilter
 
-	// Get the extAuthzConf from envs vars.
-	extAuthzConf := config.GetExternalAuthzConfig()
-
-	if extAuthzConf.Enabled {
-		filters = append(filters, extAuthzConf.HTTPFilter)
+	if config.ExternalAuthz.Enabled {
+		filters = append(filters, config.ExternalAuthz.HTTPFilter)
 	}
 
 	// Append the Router filter at the end.

--- a/pkg/envoy/lb_endpoint.go
+++ b/pkg/envoy/lb_endpoint.go
@@ -22,23 +22,21 @@ import (
 )
 
 func NewLBEndpoint(ip string, port uint32) *endpoint.LbEndpoint {
-	serviceEndpoint := &core.Address{
-		Address: &core.Address_SocketAddress{
-			SocketAddress: &core.SocketAddress{
-				Protocol: core.SocketAddress_TCP,
-				Address:  ip,
-				PortSpecifier: &core.SocketAddress_PortValue{
-					PortValue: port,
-				},
-				Ipv4Compat: true,
-			},
-		},
-	}
-
 	return &endpoint.LbEndpoint{
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
 			Endpoint: &endpoint.Endpoint{
-				Address: serviceEndpoint,
+				Address: &core.Address{
+					Address: &core.Address_SocketAddress{
+						SocketAddress: &core.SocketAddress{
+							Protocol: core.SocketAddress_TCP,
+							Address:  ip,
+							PortSpecifier: &core.SocketAddress_PortValue{
+								PortValue: port,
+							},
+							Ipv4Compat: true,
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -101,8 +101,7 @@ func (caches *Caches) UpdateIngress(ctx context.Context, ingress *v1alpha1.Ingre
 
 func (caches *Caches) initConfig(ctx context.Context, kubernetesClient kubeclient.Interface, extAuthz bool) error {
 	if extAuthz {
-		extAuthZConfig := config.GetExternalAuthzConfig()
-		caches.addClusterForIngress(extAuthZConfig.Cluster, "__extAuthZCluster", "_internal")
+		caches.addClusterForIngress(config.ExternalAuthz.Cluster, "__extAuthZCluster", "_internal")
 	}
 	caches.addStatusVirtualHost()
 	return caches.setListeners(ctx, kubernetesClient)

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 	kubeclient "k8s.io/client-go/kubernetes"
+	"knative.dev/net-kourier/pkg/config"
 	"knative.dev/net-kourier/pkg/envoy"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 )
@@ -100,7 +101,7 @@ func (caches *Caches) UpdateIngress(ctx context.Context, ingress *v1alpha1.Ingre
 
 func (caches *Caches) initConfig(ctx context.Context, kubernetesClient kubeclient.Interface, extAuthz bool) error {
 	if extAuthz {
-		extAuthZConfig := envoy.GetExternalAuthzConfig()
+		extAuthZConfig := config.GetExternalAuthzConfig()
 		caches.addClusterForIngress(extAuthZConfig.Cluster, "__extAuthZCluster", "_internal")
 	}
 	caches.addStatusVirtualHost()

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -67,7 +67,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	serviceInformer := serviceinformer.Get(ctx)
 	podInformer := podinformer.Get(ctx)
 
-	extAuthZConfig := envoy.GetExternalAuthzConfig()
+	extAuthZConfig := config.GetExternalAuthzConfig()
 
 	// Get the current list of ingresses that are ready, and pass it to the cache so we can
 	// know when it has been synced.

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -67,8 +67,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	serviceInformer := serviceinformer.Get(ctx)
 	podInformer := podinformer.Get(ctx)
 
-	extAuthZConfig := config.GetExternalAuthzConfig()
-
 	// Get the current list of ingresses that are ready, and pass it to the cache so we can
 	// know when it has been synced.
 	ingressesToSync, err := getReadyIngresses(ctx, knativeClient.NetworkingV1alpha1())
@@ -77,7 +75,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	// Create a new Cache, with the Readiness endpoint enabled, and the list of current Ingresses.
-	caches, err := generator.NewCaches(ctx, logger.Named("caches"), kubernetesClient, extAuthZConfig.Enabled, ingressesToSync)
+	caches, err := generator.NewCaches(ctx, logger.Named("caches"), kubernetesClient, config.ExternalAuthz.Enabled, ingressesToSync)
 	if err != nil {
 		logger.Fatalw("Failed create new caches", zap.Error(err))
 	}
@@ -85,7 +83,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	r := &Reconciler{
 		kubeClient: kubernetesClient,
 		caches:     caches,
-		extAuthz:   extAuthZConfig.Enabled,
+		extAuthz:   config.ExternalAuthz.Enabled,
 	}
 
 	impl := v1alpha1ingress.NewImpl(ctx, r, config.KourierIngressClassName)

--- a/test/extauthz/integration_test.go
+++ b/test/extauthz/integration_test.go
@@ -27,8 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/net-kourier/pkg/config"
-
 	"knative.dev/pkg/test"
 
 	corev1 "k8s.io/api/core/v1"
@@ -152,13 +150,13 @@ func setupExtAuthzScenario(ctx context.Context, k8sClient *kubernetes.Clientset,
 	}
 
 	ExtAuthzHostEnv := corev1.EnvVar{
-		Name:      config.ExtAuthzHostEnv,
+		Name:      "KOURIER_EXTAUTHZ_HOST",
 		Value:     "externalauthz:6000",
 		ValueFrom: nil,
 	}
 
 	ExtAuthzFailureEnv := corev1.EnvVar{
-		Name:      config.ExtAuthzFailureModeEnv,
+		Name:      "KOURIER_EXTAUTHZ_FAILUREMODEALLOW",
 		Value:     "false",
 		ValueFrom: nil,
 	}
@@ -205,7 +203,7 @@ func cleanExtAuthzScenario(ctx context.Context, kubeClient *kubernetes.Clientset
 
 	var finalEnvs []corev1.EnvVar
 	for _, env := range kourierControlDeployment.Spec.Template.Spec.Containers[0].Env {
-		if env.Name != config.ExtAuthzHostEnv && env.Name != config.ExtAuthzFailureModeEnv {
+		if env.Name != "KOURIER_EXTAUTHZ_HOST" && env.Name != "KOURIER_EXTAUTHZ_FAILUREMODEALLOW" {
 			finalEnvs = append(finalEnvs, env)
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,6 +156,7 @@ github.com/jmespath/go-jmespath
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
 # github.com/kelseyhightower/envconfig v1.4.0
+## explicit
 github.com/kelseyhightower/envconfig
 # github.com/konsorten/go-windows-terminal-sequences v1.0.3
 github.com/konsorten/go-windows-terminal-sequences


### PR DESCRIPTION
As it stands, ExtAuthz config is read multiple times during a reconcile cycle, completely unnecessary seeing as it cannot be changed at runtime.

This refactors things to:
1. Move the config to the config package.
2. Load the config only once at startup.
3. Replace manual parsing with envconfig.

**Note:** The individual commits are meaningful and can be reviewed one-by-one.