### PR TITLE
Rename common k8s imports to common aliases

### DIFF
--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
 	"gotest.tools/assert"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"knative.dev/net-kourier/pkg/config"
@@ -186,7 +186,7 @@ func createTestDataForIngress(
 	}
 
 	_ = caches.addTranslatedIngress(&v1alpha1.Ingress{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      ingressName,
 			Namespace: ingressNamespace,
 		},
@@ -276,8 +276,8 @@ func TestCacheWithWarmingWithIngressesToSync(t *testing.T) {
 
 	ingressesToSync := []*v1alpha1.Ingress{
 		{
-			TypeMeta:   v1.TypeMeta{},
-			ObjectMeta: v1.ObjectMeta{Name: "test1", Namespace: "namespace1"},
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "namespace1"},
 			Spec:       v1alpha1.IngressSpec{},
 			Status:     v1alpha1.IngressStatus{},
 		},

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -25,7 +25,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"go.uber.org/zap"
-	kubev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kubeclient "k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -208,7 +208,7 @@ func trackService(t tracker.Interface, svcName string, ingress *v1alpha1.Ingress
 	return nil
 }
 
-func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.Endpoints, targetPort int32) (publicLbEndpoints []*endpoint.LbEndpoint) {
+func lbEndpointsForKubeEndpoints(kubeEndpoints *corev1.Endpoints, targetPort int32) (publicLbEndpoints []*endpoint.LbEndpoint) {
 	for _, subset := range kubeEndpoints.Subsets {
 		for _, address := range subset.Addresses {
 			lbEndpoint := envoy.NewLBEndpoint(address.IP, uint32(targetPort))

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -26,7 +26,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/google/go-cmp/cmp"
 	"gotest.tools/assert"
-	kubev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -300,8 +300,8 @@ func newMockedEndpointsLister() corev1listers.EndpointsLister {
 
 type endpointsLister struct{}
 
-func (endpointsLister *endpointsLister) List(selector labels.Selector) ([]*kubev1.Endpoints, error) {
-	return []*kubev1.Endpoints{{}}, nil
+func (endpointsLister *endpointsLister) List(selector labels.Selector) ([]*corev1.Endpoints, error) {
+	return []*corev1.Endpoints{{}}, nil
 }
 
 func (endpointsLister *endpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
@@ -310,12 +310,12 @@ func (endpointsLister *endpointsLister) Endpoints(namespace string) corev1lister
 
 type endpoints struct{}
 
-func (endpoints *endpoints) List(selector labels.Selector) ([]*kubev1.Endpoints, error) {
-	return []*kubev1.Endpoints{{}}, nil
+func (endpoints *endpoints) List(selector labels.Selector) ([]*corev1.Endpoints, error) {
+	return []*corev1.Endpoints{{}}, nil
 }
 
-func (endpoints *endpoints) Get(name string) (*kubev1.Endpoints, error) {
-	return &kubev1.Endpoints{}, nil
+func (endpoints *endpoints) Get(name string) (*corev1.Endpoints, error) {
+	return &corev1.Endpoints{}, nil
 }
 
 func newMockedServiceLister() corev1listers.ServiceLister {
@@ -324,8 +324,8 @@ func newMockedServiceLister() corev1listers.ServiceLister {
 
 type serviceLister struct{}
 
-func (endpointsLister *serviceLister) List(selector labels.Selector) ([]*kubev1.Service, error) {
-	return []*kubev1.Service{{}}, nil
+func (endpointsLister *serviceLister) List(selector labels.Selector) ([]*corev1.Service, error) {
+	return []*corev1.Service{{}}, nil
 }
 
 func (endpointsLister *serviceLister) Services(namespace string) corev1listers.ServiceNamespaceLister {
@@ -334,12 +334,12 @@ func (endpointsLister *serviceLister) Services(namespace string) corev1listers.S
 
 type service struct{}
 
-func (endpoints *service) List(selector labels.Selector) ([]*kubev1.Service, error) {
-	return []*kubev1.Service{{}}, nil
+func (endpoints *service) List(selector labels.Selector) ([]*corev1.Service, error) {
+	return []*corev1.Service{{}}, nil
 }
 
-func (endpoints *service) Get(name string) (*kubev1.Service, error) {
-	return &kubev1.Service{}, nil
+func (endpoints *service) Get(name string) (*corev1.Service, error) {
+	return &corev1.Service{}, nil
 }
 
 func createIngress(name string, hosts []string, visibility v1alpha1.IngressVisibility) *v1alpha1.Ingress {
@@ -420,7 +420,7 @@ func createIngressWithTLS(hosts []string, secretName string, secretNamespace str
 }
 
 func createSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNamespace string, secretName string, cert string, key string) error {
-	tlsSecret := kubev1.Secret{
+	tlsSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
@@ -436,7 +436,7 @@ func createSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNa
 
 func createServicesWithNames(ctx context.Context, kubeclient kubernetes.Interface, names []string, namespace string) error {
 	for _, serviceName := range names {
-		service := kubev1.Service{
+		service := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: serviceName,
 			},

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -170,14 +170,14 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(
 		controller.EnsureTypeMeta(
 			tracker.OnChanged,
-			v1.SchemeGroupVersion.WithKind("Services"),
+			corev1.SchemeGroupVersion.WithKind("Services"),
 		),
 	))
 
 	endpointsInformer.Informer().AddEventHandler(controller.HandleAll(
 		controller.EnsureTypeMeta(
 			tracker.OnChanged,
-			v1.SchemeGroupVersion.WithKind("Endpoints"),
+			corev1.SchemeGroupVersion.WithKind("Endpoints"),
 		),
 	))
 
@@ -186,7 +186,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		Handler: cache.ResourceEventHandlerFuncs{
 			// Cancel probing when a Pod is deleted
 			DeleteFunc: func(obj interface{}) {
-				pod, ok := obj.(*v1.Pod)
+				pod, ok := obj.(*corev1.Pod)
 				if ok {
 					statusProber.CancelPodProbing(pod)
 				}

--- a/test/extauthz/integration_test.go
+++ b/test/extauthz/integration_test.go
@@ -31,7 +31,7 @@ import (
 
 	"knative.dev/pkg/test"
 
-	v12 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,13 +151,13 @@ func setupExtAuthzScenario(ctx context.Context, k8sClient *kubernetes.Clientset,
 		return nil, err
 	}
 
-	ExtAuthzHostEnv := v12.EnvVar{
+	ExtAuthzHostEnv := corev1.EnvVar{
 		Name:      config.ExtAuthzHostEnv,
 		Value:     "externalauthz:6000",
 		ValueFrom: nil,
 	}
 
-	ExtAuthzFailureEnv := v12.EnvVar{
+	ExtAuthzFailureEnv := corev1.EnvVar{
 		Name:      config.ExtAuthzFailureModeEnv,
 		Value:     "false",
 		ValueFrom: nil,
@@ -203,7 +203,7 @@ func cleanExtAuthzScenario(ctx context.Context, kubeClient *kubernetes.Clientset
 		return err
 	}
 
-	var finalEnvs []v12.EnvVar
+	var finalEnvs []corev1.EnvVar
 	for _, env := range kourierControlDeployment.Spec.Template.Spec.Containers[0].Env {
 		if env.Name != config.ExtAuthzHostEnv && env.Name != config.ExtAuthzFailureModeEnv {
 			finalEnvs = append(finalEnvs, env)


### PR DESCRIPTION
Reading the code can be somewhat confusing without these being what they usually are.