### PR TITLE
Make VirtualHost generators return pointers directly

### DIFF
--- a/pkg/envoy/listener_test.go
+++ b/pkg/envoy/listener_test.go
@@ -87,7 +87,7 @@ func TestNewHTTPSListenerWithSNI(t *testing.T) {
 		"vHost2", []string{"another_host.com", "another_host.com:*"}, []*route.Route{},
 	)
 
-	manager := NewHTTPConnectionManager([]*route.VirtualHost{&vHost1, &vHost2})
+	manager := NewHTTPConnectionManager([]*route.VirtualHost{vHost1, vHost2})
 
 	listener, err := NewHTTPSListenerWithSNI(&manager, 8443, sniMatches)
 	if err != nil {

--- a/pkg/envoy/virtual_host.go
+++ b/pkg/envoy/virtual_host.go
@@ -24,8 +24,8 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 )
 
-func NewVirtualHost(name string, domains []string, routes []*route.Route) route.VirtualHost {
-	return route.VirtualHost{
+func NewVirtualHost(name string, domains []string, routes []*route.Route) *route.VirtualHost {
+	return &route.VirtualHost{
 		Name:    name,
 		Domains: domains,
 		Routes:  routes,
@@ -33,7 +33,7 @@ func NewVirtualHost(name string, domains []string, routes []*route.Route) route.
 }
 
 func NewVirtualHostWithExtAuthz(name string, contextExtensions map[string]string, domains []string,
-	routes []*route.Route) route.VirtualHost {
+	routes []*route.Route) *route.VirtualHost {
 
 	perFilterConfig := extAuthService.ExtAuthzPerRoute{
 		Override: &extAuthService.ExtAuthzPerRoute_CheckSettings{
@@ -52,7 +52,7 @@ func NewVirtualHostWithExtAuthz(name string, contextExtensions map[string]string
 		Value:   b.Bytes(),
 	}
 
-	r := route.VirtualHost{
+	return &route.VirtualHost{
 		Name:    name,
 		Domains: domains,
 		Routes:  routes,
@@ -60,7 +60,5 @@ func NewVirtualHostWithExtAuthz(name string, contextExtensions map[string]string
 			wellknown.HTTPExternalAuthorization: filter,
 		},
 	}
-
-	return r
 
 }

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -137,8 +137,7 @@ func (caches *Caches) SetOnEvicted(f func(string, interface{})) {
 }
 
 func (caches *Caches) addStatusVirtualHost() {
-	statusVirtualHost := statusVHost()
-	caches.statusVirtualHost = &statusVirtualHost
+	caches.statusVirtualHost = statusVHost()
 }
 
 func (caches *Caches) setListeners(ctx context.Context, kubeclient kubeclient.Interface) error {

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -156,7 +156,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 		}
 
 		domains := knative.Domains(rule)
-		var virtualHost route.VirtualHost
+		var virtualHost *route.VirtualHost
 		if extAuthzEnabled {
 			contextExtensions := kmeta.UnionMaps(map[string]string{
 				"client":     "kourier",
@@ -167,9 +167,9 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 			virtualHost = envoy.NewVirtualHost(ingress.Name, domains, routes)
 		}
 
-		internalHosts = append(internalHosts, &virtualHost)
+		internalHosts = append(internalHosts, virtualHost)
 		if knative.RuleIsExternal(rule) {
-			externalHosts = append(externalHosts, &virtualHost)
+			externalHosts = append(externalHosts, virtualHost)
 		}
 	}
 

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -26,7 +26,7 @@ import (
 
 // Generates an internal virtual host that signals that the Envoy instance has
 // been configured, this endpoint is used by the kubernetes readiness probe.
-func statusVHost() route.VirtualHost {
+func statusVHost() *route.VirtualHost {
 	return envoy.NewVirtualHost(
 		config.InternalKourierDomain,
 		[]string{config.InternalKourierDomain},


### PR DESCRIPTION
This seems to be just about the only resource that's not generated as a pointer from the get-go, but it's used as a pointer everywhere. So let's spare ourselves the intermediate variables.