### PR TITLE
Use NamespacedName in a few places to make interfaces more strongly typed

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -113,8 +113,14 @@ func (caches *Caches) addTranslatedIngress(ingress *v1alpha1.Ingress, translated
 }
 
 // SetOnEvicted allows to set a function that will be executed when any key on the cache expires.
-func (caches *Caches) SetOnEvicted(f func(string, interface{})) {
-	caches.clusters.clusters.OnEvicted(f)
+func (caches *Caches) SetOnEvicted(f func(types.NamespacedName, interface{})) {
+	caches.clusters.clusters.OnEvicted(func(key string, val interface{}) {
+		_, name, namespace := explodeKey(key)
+		f(types.NamespacedName{
+			Namespace: namespace,
+			Name:      name,
+		}, val)
+	})
 }
 
 func (caches *Caches) setListeners(ctx context.Context, kubeclient kubeclient.Interface) error {

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"knative.dev/net-kourier/pkg/config"
@@ -173,8 +174,10 @@ func createTestDataForIngress(
 	kubeClient kubeclient.Interface) {
 
 	translatedIngress := translatedIngress{
-		ingressName:          ingressName,
-		ingressNamespace:     ingressNamespace,
+		name: types.NamespacedName{
+			Namespace: ingressNamespace,
+			Name:      ingressName,
+		},
 		clusters:             []*v2.Cluster{{Name: clusterName}},
 		externalVirtualHosts: []*route.VirtualHost{{Name: externalVHostName, Domains: []string{externalVHostName}}},
 		internalVirtualHosts: []*route.VirtualHost{{Name: internalVHostName, Domains: []string{internalVHostName}}},
@@ -212,8 +215,10 @@ func TestValidateIngress(t *testing.T) {
 	)
 
 	translatedIngress := translatedIngress{
-		ingressName:          "ingress_2",
-		ingressNamespace:     "ingress_2_namespace",
+		name: types.NamespacedName{
+			Namespace: "ingress_2_namespace",
+			Name:      "ingress_2",
+		},
 		clusters:             []*v2.Cluster{{Name: "cluster_for_ingress_2"}},
 		externalVirtualHosts: []*route.VirtualHost{{Name: "external_host_for_ingress_2", Domains: []string{"external_host_for_ingress_2"}}},
 		//This domain should clash with the cached ingress.

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -97,3 +97,8 @@ func (cc *ClustersCache) list() []envoycache.Resource {
 func key(clusterName, ingressName, ingressNamespace string) string {
 	return strings.Join([]string{clusterName, ingressName, ingressNamespace}, ":")
 }
+
+func explodeKey(key string) (string, string, string) {
+	keyParts := strings.Split(key, ":")
+	return keyParts[0], keyParts[1], keyParts[2]
+}

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -26,6 +26,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"knative.dev/net-kourier/pkg/envoy"
 	"knative.dev/net-kourier/pkg/knative"
@@ -36,8 +37,7 @@ import (
 )
 
 type translatedIngress struct {
-	ingressName          string
-	ingressNamespace     string
+	name                 types.NamespacedName
 	sniMatches           []*envoy.SNIMatch
 	clusters             []*v2.Cluster
 	externalVirtualHosts []*route.VirtualHost
@@ -174,8 +174,10 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 	}
 
 	return &translatedIngress{
-		ingressName:          ingress.Name,
-		ingressNamespace:     ingress.Namespace,
+		name: types.NamespacedName{
+			Namespace: ingress.Namespace,
+			Name:      ingress.Name,
+		},
 		sniMatches:           sniMatches,
 		clusters:             clusters,
 		externalVirtualHosts: externalHosts,

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -106,7 +106,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	statusProber.Start(ctx.Done())
 
 	r.caches.SetOnEvicted(func(key types.NamespacedName, value interface{}) {
-		logger.Debugf("Evicted %s", key.String())
+		logger.Debug("Evicted", key.String())
 		// We enqueue the ingress name and namespace as if it was a new event, to force
 		// a config refresh.
 		impl.EnqueueKey(key)


### PR DESCRIPTION
1. Store name of translatedIngress in structured field.
2. Switch keys of maps in cache to structured key, which makes a lot clearer what is stored in them.
3. Hide key interface in cache implementation.