### PR TITLE
Drop all usages of Knative types on caching layer

### DIFF
--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -29,12 +29,10 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
 	"gotest.tools/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"knative.dev/net-kourier/pkg/config"
-	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 )
 
 func TestDeleteIngressInfo(t *testing.T) {
@@ -173,7 +171,7 @@ func createTestDataForIngress(
 	externalVHostName string,
 	kubeClient kubeclient.Interface) {
 
-	translatedIngress := translatedIngress{
+	translatedIngress := &translatedIngress{
 		name: types.NamespacedName{
 			Namespace: ingressNamespace,
 			Name:      ingressName,
@@ -183,13 +181,7 @@ func createTestDataForIngress(
 		internalVirtualHosts: []*route.VirtualHost{{Name: internalVHostName, Domains: []string{internalVHostName}}},
 	}
 
-	_ = caches.addTranslatedIngress(&v1alpha1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ingressName,
-			Namespace: ingressNamespace,
-		},
-	}, &translatedIngress)
-
+	_ = caches.addTranslatedIngress(translatedIngress)
 	_ = caches.setListeners(ctx, kubeClient)
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -60,7 +60,7 @@ func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ing
 		return nil
 	}
 
-	return caches.UpdateIngress(ctx, ing, ingressTranslation, kubeclient)
+	return caches.UpdateIngress(ctx, ingressTranslation, kubeclient)
 }
 
 func listenersFromVirtualHosts(ctx context.Context, externalVirtualHosts []*route.VirtualHost,


### PR DESCRIPTION
This makes the split of the translation -> cache -> snapshot layers a bit more apparent by not having any of the initial types in the caching layer at all.