### PR TITLE
Fix the 'test-integration' target of the Makefile to successfully run tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test-unit-coverage: ## Runs unit tests and generates a coverage report
 	go tool cover -html="$(PROJECT_PATH)/tests_output/unit.cov"
 
 test-integration: local-setup ## Runs integration tests
-	go test -mod vendor -race test/*.go
+	./test/e2e-kind.sh
 
 .PHONY: fmt
 fmt: ## Runs code formatting

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -18,6 +18,7 @@
 
 set -euo pipefail
 
+export KO_DOCKER_REPO=kind.local
 $(dirname $0)/upload-test-images.sh
 
 ips=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs e2e tests on a local kind environment.
+
+set -euo pipefail
+
+$(dirname $0)/upload-test-images.sh
+
+ips=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
+
+export "GATEWAY_OVERRIDE=kourier"
+export "GATEWAY_NAMESPACE_OVERRIDE=kourier-system"
+
+echo ">> Running conformance tests"
+go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... \
+  --enable-alpha --enable-beta --skip-tests="host-rewrite" \
+  --ingressendpoint="${ips[0]}" \
+  --ingressClass=kourier.ingress.networking.knative.dev
+
+echo ">> Scale up components for HA tests"
+kubectl -n kourier-system  scale deployment 3scale-kourier-gateway --replicas=2
+kubectl -n knative-serving scale deployment 3scale-kourier-control --replicas=2
+
+echo ">> Running HA tests"
+go test -count=1 -timeout=15m -failfast -parallel=1 -tags=e2e ./test/ha -spoofinterval="10ms" \
+  --ingressendpoint="${ips[0]}" \
+  --ingressClass=kourier.ingress.networking.knative.dev

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -19,6 +19,7 @@
 set -euo pipefail
 
 export KO_DOCKER_REPO=kind.local
+export KIND_CLUSTER_NAME="kourier-integration"
 $(dirname $0)/upload-test-images.sh
 
 ips=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -32,3 +32,10 @@ for d in $(kubectl -n ${KOURIER_GATEWAY_NAMESPACE} get deploy -oname)
 do
   kubectl -n "${KOURIER_GATEWAY_NAMESPACE}" wait --timeout=300s --for=condition=Available "$d"
 done
+
+ips=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
+port=$(kubectl -n kourier-system get svc kourier -ojsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+echo
+echo "You can connect to Kourier at ${ips[0]}:${port}"
+echo "Consider exporting it via 'export KOURIER_IP=${ips[0]}:${port}'"
+echo "Example usage: 'curl -H \"Host: helloworld.default.example.com\" \$KOURIER_IP'"

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -17,7 +17,7 @@ kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_
 kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 echo "Deploying Kourier"
-export KO_DOCKER_REPO
+export KO_DOCKER_REPO=kind.local
 ko resolve -f test/config -f deploy/kourier-knative.yaml | \
   sed 's/LoadBalancer/NodePort/g' | \
   kubectl apply -f -

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -14,11 +14,13 @@ echo "Deploying Knative Serving"
 KNATIVE_VERSION=v0.18.0
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
-kubectl patch configmap/config-domain -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 echo "Deploying Kourier"
-KO_DOCKER_REPO=kind.local ko apply -Rf deploy/kourier-knative.yaml
+export KO_DOCKER_REPO
+ko resolve -f test/config -f deploy/kourier-knative.yaml | \
+  sed 's/LoadBalancer/NodePort/g' | \
+  kubectl apply -f -
 
 echo "Wait for all deployments to be up"
 for d in $(kubectl -n ${KOURIER_CONTROL_NAMESPACE} get deploy -oname)
@@ -30,6 +32,3 @@ for d in $(kubectl -n ${KOURIER_GATEWAY_NAMESPACE} get deploy -oname)
 do
   kubectl -n "${KOURIER_GATEWAY_NAMESPACE}" wait --timeout=300s --for=condition=Available "$d"
 done
-
-# shellcheck disable=SC2046
-kubectl port-forward --namespace ${KOURIER_GATEWAY_NAMESPACE} "$(kubectl get pod -n ${KOURIER_GATEWAY_NAMESPACE} -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &


### PR DESCRIPTION
This does a few things to successfully bring back local integration testing:

1. Replace port-forwarding with setting up a NodePort.
2. Add a script geared towards local testing that fetches the correct IP etc.
3. Call that script.

**Note:** This doesn't contain extAuth tests just yet. They need a bit more massaging.