### PR TITLE
Use 'auto' for coverage checks to rely on the current actual coverage

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,7 +4,7 @@ coverage:
   status:
     project:
       default:
-        target: 80
+        target: auto
         threshold: 1%
     patch:
       # Disable the coverage threshold of the patch, so that PRs are


### PR DESCRIPTION
We've never even been close to 80% (yet). We should revisit this later but get it out of the way for the time being.