### PR TITLE
Split config into files and rename the folder to config

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -127,7 +127,7 @@ jobs:
         # Build and Publish our containers to the docker daemon (including test assets)
         export GO111MODULE=on
         export GOFLAGS=-mod=vendor
-        ko resolve -f test/config/ -f deploy/kourier-knative.yaml | \
+        ko resolve -f test/config/ -f config/ | \
           sed 's/LoadBalancer/NodePort/g' | \
           kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ different namespaces:
 
 To change the Kourier gateway namespace, you will need to:
 
-- Modify the `deploy/kourier-knative.yaml` file, and replace all the namespaces
-  fields that have `kourier-system` with the desired namespace.
+- Modify the files in `config/` and replace all the namespaces fields that have
+  `kourier-system` with the desired namespace.
 - Set the `KOURIER_GATEWAY_NAMESPACE` env var in the kourier-control deployment
   to the new namespace.
 

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kourier-system
+  labels:
+    networking.knative.dev/ingress-provider: kourier

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -1,0 +1,66 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 3scale-kourier
+  namespace: knative-serving
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: 3scale-kourier
+  namespace: knative-serving
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","update","patch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "namespaces", "services", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch","update","create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["networking.internal.knative.dev"]
+    resources: ["ingresses/status"]
+    verbs: ["update"]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: 3scale-kourier
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 3scale-kourier
+subjects:
+  - kind: ServiceAccount
+    name: 3scale-kourier
+    namespace: knative-serving

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -1,0 +1,77 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-control
+  namespace: knative-serving
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 3scale-kourier-control
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-control
+    spec:
+      containers:
+        - image: ko://knative.dev/net-kourier/cmd/kourier
+          name: kourier-control
+          env:
+            - name: CERTS_SECRET_NAMESPACE
+              value: ""
+            - name: CERTS_SECRET_NAME
+              value: ""
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: METRICS_DOMAIN
+              value: "knative.dev/samples"
+            - name: KOURIER_GATEWAY_NAMESPACE
+              value: "kourier-system"
+          ports:
+          - name: http2-xds
+            containerPort: 18000
+            protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
+      restartPolicy: Always
+      serviceAccountName: 3scale-kourier
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-control
+  namespace: knative-serving
+  labels:
+    networking.knative.dev/ingress-provider: kourier
+spec:
+  ports:
+    - name: grpc-xds
+      port: 18000
+      protocol: TCP
+      targetPort: 18000
+  selector:
+    app: 3scale-kourier-control
+  type: ClusterIP

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -1,31 +1,17 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier
-  namespace: kourier-system
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-spec:
-  ports:
-    - name: http2
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-    - name: https
-      port: 443
-      protocol: TCP
-      targetPort: 8443
-  selector:
-    app: 3scale-kourier-gateway
-  type: LoadBalancer
----
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,105 +77,26 @@ spec:
             name: kourier-bootstrap
       restartPolicy: Always
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Service
 metadata:
-  name: 3scale-kourier-control
-  namespace: knative-serving
+  name: kourier
+  namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
 spec:
-  replicas: 1
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
   selector:
-    matchLabels:
-      app: 3scale-kourier-control
-  template:
-    metadata:
-      labels:
-        app: 3scale-kourier-control
-    spec:
-      containers:
-        - image: ko://knative.dev/net-kourier/cmd/kourier
-          name: kourier-control
-          env:
-            - name: CERTS_SECRET_NAMESPACE
-              value: ""
-            - name: CERTS_SECRET_NAME
-              value: ""
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: METRICS_DOMAIN
-              value: "knative.dev/samples"
-            - name: KOURIER_GATEWAY_NAMESPACE
-              value: "kourier-system"
-          ports:
-          - name: http2-xds
-            containerPort: 18000
-            protocol: TCP
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - all
-      restartPolicy: Always
-      serviceAccountName: 3scale-kourier
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: 3scale-kourier
-  namespace: knative-serving
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create","update","patch"]
-  - apiGroups: [""]
-    resources: ["pods", "endpoints", "namespaces", "services", "secrets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch","update","create"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["networking.internal.knative.dev"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch", "patch"]
-  - apiGroups: ["networking.internal.knative.dev"]
-    resources: ["ingresses/status"]
-    verbs: ["update"]
-  - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: 3scale-kourier
-  namespace: knative-serving
-  labels:
-    networking.knative.dev/ingress-provider: kourier
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: 3scale-kourier
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: 3scale-kourier
-subjects:
-  - kind: ServiceAccount
-    name: 3scale-kourier
-    namespace: knative-serving
+    app: 3scale-kourier-gateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
@@ -206,23 +113,6 @@ spec:
       targetPort: 8081
   selector:
     app: 3scale-kourier-gateway
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-control
-  namespace: knative-serving
-  labels:
-    networking.knative.dev/ingress-provider: kourier
-spec:
-  ports:
-    - name: grpc-xds
-      port: 18000
-      protocol: TCP
-      targetPort: 18000
-  selector:
-    app: 3scale-kourier-control
   type: ClusterIP
 ---
 apiVersion: v1

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,7 +22,7 @@ source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["kourier.yaml"]="deploy"
+  ["kourier.yaml"]="config"
 )
 readonly COMPONENTS
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -41,7 +41,7 @@ function test_setup() {
 
   # Bringing up controllers.
   echo ">> Bringing up Kourier"
-  sed 's/--log-level info/--log-level debug/g' deploy/kourier-knative.yaml | ko apply -f - || return 1
+  ko resolve -f config | sed 's/--log-level info/--log-level debug/g' | ko apply -f - || return 1
 
   scale_deployment 3scale-kourier-control "${KOURIER_CONTROL_NAMESPACE}"
   scale_deployment 3scale-kourier-gateway "${GATEWAY_NAMESPACE_OVERRIDE}"

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -18,7 +18,7 @@ kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '
 
 echo "Deploying Kourier"
 export KO_DOCKER_REPO=kind.local
-ko resolve -f test/config -f deploy/kourier-knative.yaml | \
+ko resolve -f test/config -f config | \
   sed 's/LoadBalancer/NodePort/g' | \
   kubectl apply -f -
 


### PR DESCRIPTION
As per title, this aligns us closer with other Knative projects in that we use the canonical `config` folder and split the YAML files into logical components to make changing and reading them somewhat easier.