### PR TITLE
Use 'global' client instead of passing it through in each request

### DIFF
--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/types"
-	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"knative.dev/net-kourier/pkg/config"
 )
@@ -54,7 +53,6 @@ func TestDeleteIngressInfo(t *testing.T) {
 		"cluster_for_ingress_1",
 		"internal_host_for_ingress_1",
 		"external_host_for_ingress_1",
-		&kubeClient,
 	)
 
 	// Add info for a different ingress
@@ -68,11 +66,10 @@ func TestDeleteIngressInfo(t *testing.T) {
 		"cluster_for_ingress_2",
 		"internal_host_for_ingress_2",
 		"external_host_for_ingress_2",
-		&kubeClient,
 	)
 
 	// Delete the first ingress
-	_ = caches.DeleteIngressInfo(ctx, firstIngressName, firstIngressNamespace, &kubeClient)
+	_ = caches.DeleteIngressInfo(ctx, firstIngressName, firstIngressNamespace)
 
 	// Check that the listeners only have the virtual hosts of the second
 	// ingress.
@@ -114,7 +111,6 @@ func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 		"cluster_for_ingress_1",
 		"internal_host_for_ingress_1",
 		"external_host_for_ingress_1",
-		&kubeClient,
 	)
 
 	snapshotBeforeDelete, err := caches.ToEnvoySnapshot()
@@ -126,7 +122,7 @@ func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 	routesBeforeDelete := snapshotBeforeDelete.GetResources(cache.RouteType)
 	listenersBeforeDelete := snapshotBeforeDelete.GetResources(cache.ListenerType)
 
-	err = caches.DeleteIngressInfo(ctx, "non_existing_name", "non_existing_namespace", &kubeClient)
+	err = caches.DeleteIngressInfo(ctx, "non_existing_name", "non_existing_namespace")
 	if err != nil {
 		t.FailNow()
 	}
@@ -165,8 +161,7 @@ func createTestDataForIngress(
 	ingressNamespace string,
 	clusterName string,
 	internalVHostName string,
-	externalVHostName string,
-	kubeClient kubeclient.Interface) {
+	externalVHostName string) {
 
 	translatedIngress := &translatedIngress{
 		name: types.NamespacedName{
@@ -179,7 +174,7 @@ func createTestDataForIngress(
 	}
 
 	_ = caches.addTranslatedIngress(translatedIngress)
-	_ = caches.setListeners(ctx, kubeClient)
+	_ = caches.setListeners(ctx)
 }
 
 func TestValidateIngress(t *testing.T) {
@@ -199,7 +194,6 @@ func TestValidateIngress(t *testing.T) {
 		"cluster_for_ingress_1",
 		"internal_host_for_ingress_1",
 		"external_host_for_ingress_1",
-		&kubeClient,
 	)
 
 	translatedIngress := translatedIngress{

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -44,7 +44,7 @@ const (
 
 // For now, when updating the info for an ingress we delete it, and then
 // regenerate it. We can optimize this later.
-func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ingress, kubeclient kubeclient.Interface, translator *IngressTranslator, extAuthzEnabled bool) error {
+func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ingress, translator *IngressTranslator, extAuthzEnabled bool) error {
 	// Adds a header with the ingress Hash and a random value header to force the config reload.
 	_, err := ingress.InsertProbe(ing)
 	if err != nil {
@@ -60,7 +60,7 @@ func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ing
 		return nil
 	}
 
-	return caches.UpdateIngress(ctx, ingressTranslation, kubeclient)
+	return caches.UpdateIngress(ctx, ingressTranslation)
 }
 
 func listenersFromVirtualHosts(ctx context.Context, externalVirtualHosts []*route.VirtualHost,

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
-	kubeclient "k8s.io/client-go/kubernetes"
 	"knative.dev/net-kourier/pkg/config"
 	envoy "knative.dev/net-kourier/pkg/envoy/server"
 	"knative.dev/net-kourier/pkg/generator"
@@ -36,7 +35,6 @@ import (
 
 type Reconciler struct {
 	xdsServer         *envoy.XdsServer
-	kubeClient        kubeclient.Interface
 	caches            *generator.Caches
 	statusManager     *status.Prober
 	ingressTranslator *generator.IngressTranslator
@@ -92,7 +90,7 @@ func (r *Reconciler) ObserveFinalizeKind(ctx context.Context, ing *v1alpha1.Ingr
 
 	r.statusManager.CancelIngressProbing(ing)
 
-	if err := r.caches.DeleteIngressInfo(ctx, ing.Name, ing.Namespace, r.kubeClient); err != nil {
+	if err := r.caches.DeleteIngressInfo(ctx, ing.Name, ing.Namespace); err != nil {
 		return err
 	}
 
@@ -104,8 +102,7 @@ func (r *Reconciler) updateIngress(ctx context.Context, ingress *v1alpha1.Ingres
 	logger.Infof("Updating Ingress %s namespace: %s", ingress.Name, ingress.Namespace)
 
 	if err := generator.UpdateInfoForIngress(
-		ctx, r.caches, ingress, r.kubeClient, r.ingressTranslator, r.extAuthz,
-	); err != nil {
+		ctx, r.caches, ingress, r.ingressTranslator, r.extAuthz); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This simplifies calling code a bit by not having to pass kubeclients through at so many occasions. Instead, the cache takes a kubeclient (as it used to anyway) and uses that in its methods.