### PR TITLE
Avoid certificate conversion to string from secret

### DIFF
--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -30,11 +30,11 @@ import (
 
 type SNIMatch struct {
 	hosts            []string
-	certificateChain string
-	privateKey       string
+	certificateChain []byte
+	privateKey       []byte
 }
 
-func NewSNIMatch(hosts []string, certificateChain string, privateKey string) SNIMatch {
+func NewSNIMatch(hosts []string, certificateChain []byte, privateKey []byte) SNIMatch {
 	return SNIMatch{
 		hosts:            hosts,
 		certificateChain: certificateChain,
@@ -63,8 +63,8 @@ func NewHTTPListener(manager *httpconnmanagerv2.HttpConnectionManager, port uint
 
 func NewHTTPSListener(manager *httpconnmanagerv2.HttpConnectionManager,
 	port uint32,
-	certificateChain string,
-	privateKey string) (*v2.Listener, error) {
+	certificateChain []byte,
+	privateKey []byte) (*v2.Listener, error) {
 
 	filters, err := createFilters(manager)
 	if err != nil {
@@ -184,16 +184,16 @@ func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, 
 	return res, nil
 }
 
-func createTLSContext(certificate string, privateKey string) *auth.DownstreamTlsContext {
+func createTLSContext(certificate []byte, privateKey []byte) *auth.DownstreamTlsContext {
 	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			TlsCertificates: []*auth.TlsCertificate{
 				{
 					CertificateChain: &core.DataSource{
-						Specifier: &core.DataSource_InlineBytes{InlineBytes: []byte(certificate)},
+						Specifier: &core.DataSource_InlineBytes{InlineBytes: certificate},
 					},
 					PrivateKey: &core.DataSource{
-						Specifier: &core.DataSource_InlineBytes{InlineBytes: []byte(privateKey)},
+						Specifier: &core.DataSource_InlineBytes{InlineBytes: privateKey},
 					},
 				},
 			},

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -147,24 +147,19 @@ func useHTTPSListenerWithOneCert() bool {
 		os.Getenv(envCertsSecretName) != ""
 }
 
-func sslCreds(ctx context.Context, kubeClient kubeclient.Interface, secretNamespace string, secretName string) (certificateChain string, privateKey string, err error) {
+func sslCreds(ctx context.Context, kubeClient kubeclient.Interface, secretNamespace string, secretName string) (certificateChain []byte, privateKey []byte, err error) {
 	secret, err := kubeClient.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
-
 	if err != nil {
-		return "", "", err
+		return nil, nil, err
 	}
 
-	certificateChain = string(secret.Data[certFieldInSecret])
-	privateKey = string(secret.Data[keyFieldInSecret])
-
-	return certificateChain, privateKey, nil
+	return secret.Data[certFieldInSecret], secret.Data[keyFieldInSecret], nil
 }
 
 func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnmanagerv2.HttpConnectionManager, kubeClient kubeclient.Interface) (*v2.Listener, error) {
 	certificateChain, privateKey, err := sslCreds(
 		ctx, kubeClient, os.Getenv(envCertsSecretNamespace), os.Getenv(envCertsSecretName),
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -229,8 +229,8 @@ func TestIngressWithTLS(t *testing.T) {
 	tlsSecretName := "tls-secret"
 	tlsSecretNamespace := "default"
 	tlsHosts := []string{"hello-world.example.com"}
-	tlsCert := "some-cert"
-	tlsKey := "tls-key"
+	tlsCert := []byte("some-cert")
+	tlsKey := []byte("tls-key")
 	svcNamespace := "default"
 	ctx := context.Background()
 
@@ -377,14 +377,14 @@ func createIngressWithTLS(hosts []string, secretName string, secretNamespace str
 
 }
 
-func createSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNamespace string, secretName string, cert string, key string) error {
+func createSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNamespace string, secretName string, cert []byte, key []byte) error {
 	tlsSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
 		Data: map[string][]byte{
-			certFieldInSecret: []byte(cert),
-			keyFieldInSecret:  []byte(key),
+			certFieldInSecret: cert,
+			keyFieldInSecret:  key,
 		},
 	}
 


### PR DESCRIPTION
A secret delivers `[]byte` and the API requires `[]byte`, so there is no reason to cast in between. Casting into a string is relatively costly and not necessary at all in this case as the value is opaque anyway.