### PR TITLE
Reduce unnecessary RBAC rules

### DIFF
--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -30,13 +30,13 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create","update","patch"]
+    verbs: ["create", "update", "patch"]
   - apiGroups: [""]
-    resources: ["pods", "endpoints", "namespaces", "services", "secrets"]
+    resources: ["pods", "endpoints", "services", "secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "watch", "update","create"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
@@ -46,9 +46,6 @@ rules:
   - apiGroups: ["networking.internal.knative.dev"]
     resources: ["ingresses/status"]
     verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
I don't think we ever update or create ConfigMaps, nor do we need to do anything with CRDs or Namespaces, I believe.