### PR TITLE
Refactor lister generator to not rely on mutability

### DIFF
--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -19,22 +19,11 @@ package envoy
 import (
 	"testing"
 
-	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	envoy_config_filter_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	"github.com/golang/protobuf/ptypes"
 	"gotest.tools/assert"
 )
-
-var testVirtualHosts = []*route.VirtualHost{{
-	Name:    "helloworld-go",
-	Domains: []string{"helloworld-go.default.127.0.0.1.nip.io"},
-	Routes: []*route.Route{
-		{
-			Name: "helloworld-route",
-		},
-	},
-}}
 
 func TestCreatesManagerThatOutputsToStdOut(t *testing.T) {
 	connManager := NewHTTPConnectionManager()

--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -22,7 +22,6 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	envoy_config_filter_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
-	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/golang/protobuf/ptypes"
 	"gotest.tools/assert"
 )
@@ -37,17 +36,8 @@ var testVirtualHosts = []*route.VirtualHost{{
 	},
 }}
 
-func TestCreatesManagerWithVirtualHosts(t *testing.T) {
-	connManager := NewHTTPConnectionManager(testVirtualHosts)
-
-	VirtualHosts := connManager.RouteSpecifier.(*httpconnectionmanagerv2.HttpConnectionManager_RouteConfig).
-		RouteConfig.VirtualHosts
-
-	assert.DeepEqual(t, VirtualHosts, testVirtualHosts)
-}
-
 func TestCreatesManagerThatOutputsToStdOut(t *testing.T) {
-	connManager := NewHTTPConnectionManager(testVirtualHosts)
+	connManager := NewHTTPConnectionManager()
 	accessLog := connManager.AccessLog[0]
 	accessLogPathAny := accessLog.ConfigType.(*envoy_config_filter_accesslog_v2.AccessLog_TypedConfig).TypedConfig
 	fileAccesLog := &accesslog_v2.FileAccessLog{}

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -140,7 +140,7 @@ func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, 
 		// matching rules. For each sniMatch, we just need the rules defined for
 		// the same hosts defined in the sniMatch
 		connManager := filterByDomains(manager, sniMatch.hosts)
-		filters, err := createFilters(&connManager)
+		filters, err := createFilters(connManager)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -26,7 +26,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
@@ -163,14 +162,14 @@ func getTLSCreds(filterChain *envoy_api_v2_listener.FilterChain) (certChain []by
 
 // Note: Returns an error when there are multiple virtual hosts configured
 func getVHostDomains(filterChain *envoy_api_v2_listener.FilterChain) ([]string, error) {
-	connManager := httpconnectionmanagerv2.HttpConnectionManager{}
+	connManager := httpconnmanagerv2.HttpConnectionManager{}
 	err := ptypes.UnmarshalAny(filterChain.Filters[0].GetTypedConfig(), &connManager)
 
 	if err != nil {
 		return nil, err
 	}
 
-	routeConfig := connManager.GetRouteSpecifier().(*httpconnectionmanagerv2.HttpConnectionManager_RouteConfig).RouteConfig
+	routeConfig := connManager.GetRouteSpecifier().(*httpconnmanagerv2.HttpConnectionManager_RouteConfig).RouteConfig
 
 	if len(routeConfig.VirtualHosts) > 1 {
 		return nil, fmt.Errorf("more than one virtual host configured")

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -27,6 +27,7 @@ import (
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"gotest.tools/assert"
@@ -34,9 +35,9 @@ import (
 )
 
 func TestNewHTTPListener(t *testing.T) {
-	manager := NewHTTPConnectionManager([]*route.VirtualHost{})
+	manager := NewHTTPConnectionManager()
 
-	l, err := NewHTTPListener(&manager, 8080)
+	l, err := NewHTTPListener(manager, 8080)
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,12 +49,12 @@ func TestNewHTTPListener(t *testing.T) {
 }
 
 func TestNewHTTPSListener(t *testing.T) {
-	manager := NewHTTPConnectionManager([]*route.VirtualHost{})
+	manager := NewHTTPConnectionManager()
 
 	certChain := []byte("some_certificate_chain")
 	privateKey := []byte("some_private_key")
 
-	l, err := NewHTTPSListener(&manager, 8081, certChain, privateKey)
+	l, err := NewHTTPSListener(manager, 8081, certChain, privateKey)
 	if err != nil {
 		t.Error(err)
 	}
@@ -87,9 +88,12 @@ func TestNewHTTPSListenerWithSNI(t *testing.T) {
 		"vHost2", []string{"another_host.com", "another_host.com:*"}, []*route.Route{},
 	)
 
-	manager := NewHTTPConnectionManager([]*route.VirtualHost{vHost1, vHost2})
+	manager := NewHTTPConnectionManager()
+	manager.RouteSpecifier = &httpconnmanagerv2.HttpConnectionManager_RouteConfig{
+		RouteConfig: NewRouteConfig("test", []*route.VirtualHost{vHost1, vHost2}),
+	}
 
-	listener, err := NewHTTPSListenerWithSNI(&manager, 8443, sniMatches)
+	listener, err := NewHTTPSListenerWithSNI(manager, 8443, sniMatches)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -41,7 +41,7 @@ type Caches struct {
 	translatedIngresses map[types.NamespacedName]*translatedIngress
 	clusters            *ClustersCache
 	domainsInUse        sets.String
-	routeConfig         []v2.RouteConfiguration
+	routeConfig         []*v2.RouteConfiguration
 	listeners           []*v2.Listener
 	statusVirtualHost   *route.VirtualHost
 
@@ -164,7 +164,7 @@ func (caches *Caches) ToEnvoySnapshot() (cache.Snapshot, error) {
 		// in the Knative serving test suite fails sometimes.
 		// Ref: https://github.com/knative/serving/blob/f6da03e5dfed78593c4f239c3c7d67c5d7c55267/test/conformance/ingress/update_test.go#L37
 		caches.routeConfig[i].ValidateClusters = &wrappers.BoolValue{Value: true}
-		routes[i] = &caches.routeConfig[i]
+		routes[i] = caches.routeConfig[i]
 	}
 
 	listeners := make([]cache.Resource, len(caches.listeners))

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -211,7 +211,7 @@ func TestValidateIngress(t *testing.T) {
 	assert.Error(t, err, ErrDomainConflict.Error())
 }
 
-func getVHostsNames(routeConfigs []v2.RouteConfiguration) []string {
+func getVHostsNames(routeConfigs []*v2.RouteConfiguration) []string {
 	var res []string
 
 	for _, routeConfig := range routeConfigs {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -79,9 +79,8 @@ func listenersFromVirtualHosts(
 	// Now we setup connection managers, that reference the routeconfigs via RDS.
 	externalManager := envoy.NewHTTPConnectionManager()
 	internalManager := envoy.NewHTTPConnectionManager()
-	internalManager.RouteSpecifier = envoy.NewRDSHTTPConnectionManager(internalRouteConfigName)
-	externalManager.RouteSpecifier = envoy.NewRDSHTTPConnectionManager(externalRouteConfigName)
-
+	externalManager.RouteSpecifier = envoy.NewRDSHTTPConnectionManager(externalRouteConfig.Name)
+	internalManager.RouteSpecifier = envoy.NewRDSHTTPConnectionManager(internalRouteConfig.Name)
 	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal)
 	if err != nil {
 		return nil, err

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -74,7 +74,7 @@ func listenersFromVirtualHosts(
 	// First, we save the RouteConfigs with the proper name and all the virtualhosts etc. into the cache.
 	externalRouteConfig := envoy.NewRouteConfig(externalRouteConfigName, externalVirtualHosts)
 	internalRouteConfig := envoy.NewRouteConfig(internalRouteConfigName, clusterLocalVirtualHosts)
-	caches.routeConfig = []v2.RouteConfiguration{*externalRouteConfig, *internalRouteConfig}
+	caches.routeConfig = []*v2.RouteConfiguration{externalRouteConfig, internalRouteConfig}
 
 	// Now we setup connection managers, that reference the routeconfigs via RDS.
 	externalManager := envoy.NewHTTPConnectionManager()


### PR DESCRIPTION
I had to read `listenersFromVirtualHosts` more often than I'd like to be able to understand it, mostly because it relies on implicit copying of structs and mutability a lot.

This is step 1 of a bigger refactor of this that tries to make it simpler and more straightforward to read.