### PR TITLE
Make sure to delete watchers if the observer is removed

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -186,6 +186,14 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 
+	// Make sure trackers are deleted once the observers are removed.
+	ingressInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: isKourierIngress,
+		Handler: cache.ResourceEventHandlerFuncs{
+			DeleteFunc: tracker.OnDeletedObserver,
+		},
+	})
+
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(
 		controller.EnsureTypeMeta(
 			tracker.OnChanged,


### PR DESCRIPTION
As per title. This avoids some noop reconciles and is generally good practice.