### PR TITLE
Deduplicate SNIMatches to optimize configuration memory usage

### DIFF
--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -26,17 +26,20 @@ import (
 	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type SNIMatch struct {
 	hosts            []string
+	certSource       types.NamespacedName
 	certificateChain []byte
 	privateKey       []byte
 }
 
-func NewSNIMatch(hosts []string, certificateChain []byte, privateKey []byte) SNIMatch {
+func NewSNIMatch(hosts []string, certSource types.NamespacedName, certificateChain []byte, privateKey []byte) SNIMatch {
 	return SNIMatch{
 		hosts:            hosts,
+		certSource:       certSource,
 		certificateChain: certificateChain,
 		privateKey:       privateKey,
 	}

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -30,18 +30,18 @@ import (
 )
 
 type SNIMatch struct {
-	hosts            []string
-	certSource       types.NamespacedName
-	certificateChain []byte
-	privateKey       []byte
+	Hosts            []string
+	CertSource       types.NamespacedName
+	CertificateChain []byte
+	PrivateKey       []byte
 }
 
 func NewSNIMatch(hosts []string, certSource types.NamespacedName, certificateChain []byte, privateKey []byte) *SNIMatch {
 	return &SNIMatch{
-		hosts:            hosts,
-		certSource:       certSource,
-		certificateChain: certificateChain,
-		privateKey:       privateKey,
+		Hosts:            hosts,
+		CertSource:       certSource,
+		CertificateChain: certificateChain,
+		PrivateKey:       privateKey,
 	}
 }
 
@@ -144,7 +144,7 @@ func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, 
 			return nil, err
 		}
 
-		tlsContext := createTLSContext(sniMatch.certificateChain, sniMatch.privateKey)
+		tlsContext := createTLSContext(sniMatch.CertificateChain, sniMatch.PrivateKey)
 		tlsAny, err := ptypes.MarshalAny(tlsContext)
 		if err != nil {
 			return nil, err
@@ -152,7 +152,7 @@ func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, 
 
 		filterChain := listener.FilterChain{
 			FilterChainMatch: &listener.FilterChainMatch{
-				ServerNames: sniMatch.hosts,
+				ServerNames: sniMatch.Hosts,
 			},
 			TransportSocket: &core.TransportSocket{
 				Name:       "tls",

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -36,8 +36,8 @@ type SNIMatch struct {
 	privateKey       []byte
 }
 
-func NewSNIMatch(hosts []string, certSource types.NamespacedName, certificateChain []byte, privateKey []byte) SNIMatch {
-	return SNIMatch{
+func NewSNIMatch(hosts []string, certSource types.NamespacedName, certificateChain []byte, privateKey []byte) *SNIMatch {
+	return &SNIMatch{
 		hosts:            hosts,
 		certSource:       certSource,
 		certificateChain: certificateChain,

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -69,13 +69,13 @@ func TestNewHTTPSListener(t *testing.T) {
 
 func TestNewHTTPSListenerWithSNI(t *testing.T) {
 	sniMatches := []*SNIMatch{{
-		hosts:            []string{"some_host.com"},
-		certificateChain: []byte("cert1"),
-		privateKey:       []byte("key1"),
+		Hosts:            []string{"some_host.com"},
+		CertificateChain: []byte("cert1"),
+		PrivateKey:       []byte("key1"),
 	}, {
-		hosts:            []string{"another_host.com"},
-		certificateChain: []byte("cert2"),
-		privateKey:       []byte("key2"),
+		Hosts:            []string{"another_host.com"},
+		CertificateChain: []byte("cert2"),
+		PrivateKey:       []byte("key2"),
 	}}
 
 	manager := NewHTTPConnectionManager("test")
@@ -96,13 +96,13 @@ func TestNewHTTPSListenerWithSNI(t *testing.T) {
 }
 
 func assertListenerHasSNIMatchConfigured(t *testing.T, listener *envoy_api_v2.Listener, match *SNIMatch) {
-	filterChainFirstSNIMatch := getFilterChainByServerName(listener, match.hosts)
+	filterChainFirstSNIMatch := getFilterChainByServerName(listener, match.Hosts)
 	assert.Assert(t, filterChainFirstSNIMatch != nil)
 
 	certChain, privateKey, err := getTLSCreds(filterChainFirstSNIMatch)
 	assert.NilError(t, err)
-	assert.DeepEqual(t, match.certificateChain, certChain)
-	assert.DeepEqual(t, match.privateKey, privateKey)
+	assert.DeepEqual(t, match.CertificateChain, certChain)
+	assert.DeepEqual(t, match.PrivateKey, privateKey)
 }
 
 func getFilterChainByServerName(listener *envoy_api_v2.Listener, serverNames []string) *envoy_api_v2_listener.FilterChain {

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -76,7 +76,15 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 			return nil, fmt.Errorf("failed to fetch secret: %w", err)
 		}
 
-		sniMatch := envoy.NewSNIMatch(ingressTLS.Hosts, secret.Data[certFieldInSecret], secret.Data[keyFieldInSecret])
+		secretRef := types.NamespacedName{
+			Namespace: ingressTLS.SecretNamespace,
+			Name:      ingressTLS.SecretName,
+		}
+		sniMatch := envoy.NewSNIMatch(
+			ingressTLS.Hosts,
+			secretRef,
+			secret.Data[certFieldInSecret],
+			secret.Data[keyFieldInSecret])
 		sniMatches = append(sniMatches, &sniMatch)
 	}
 

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -80,12 +80,11 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 			Namespace: ingressTLS.SecretNamespace,
 			Name:      ingressTLS.SecretName,
 		}
-		sniMatch := envoy.NewSNIMatch(
+		sniMatches = append(sniMatches, envoy.NewSNIMatch(
 			ingressTLS.Hosts,
 			secretRef,
 			secret.Data[certFieldInSecret],
-			secret.Data[keyFieldInSecret])
-		sniMatches = append(sniMatches, &sniMatch)
+			secret.Data[keyFieldInSecret]))
 	}
 
 	internalHosts := make([]*route.VirtualHost, 0, len(ingress.Spec.Rules))

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -271,7 +271,7 @@ func TestIngressWithTLS(t *testing.T) {
 	assert.DeepEqual(
 		t,
 		envoy.NewSNIMatch(tlsHosts, secretRef, tlsCert, tlsKey),
-		*translatedIngress.sniMatches[0],
+		translatedIngress.sniMatches[0],
 		cmp.AllowUnexported(envoy.SNIMatch{}),
 	)
 }

--- a/pkg/generator/sni.go
+++ b/pkg/generator/sni.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	envoy "knative.dev/net-kourier/pkg/envoy/api"
+)
+
+// dedupedSNIMatch is a helper type that keeps the set of all added hosts as a set to
+// optimize lookup times for hosts to add.
+type dedupedSNIMatch struct {
+	sniMatch *envoy.SNIMatch
+	hosts    sets.String
+}
+
+// sniMatches is a collection of deduplicated sni matches that can be used to deduplicate
+// an existing list of sniMatches to avoid allocating a lot of configuration memory for
+// tls configurations that are essentially equal.
+// SNIMatches are deduplicated and collapsed by collapsing the list of hosts of all
+// matches that have the same certificate source (i.e. reference the same Secret).
+type sniMatches map[types.NamespacedName]*dedupedSNIMatch
+
+func (s sniMatches) consume(match *envoy.SNIMatch) {
+	state := s[match.CertSource]
+	if state == nil {
+		state = &dedupedSNIMatch{
+			sniMatch: match,
+			hosts:    sets.NewString(match.Hosts...),
+		}
+		s[match.CertSource] = state
+		return
+	}
+
+	for _, host := range match.Hosts {
+		if !state.hosts.Has(host) {
+			state.sniMatch.Hosts = append(state.sniMatch.Hosts, host)
+			state.hosts.Insert(host)
+		}
+	}
+}
+
+// list returns the deduplicated and collapsed list of SNIMatches.
+func (s sniMatches) list() []*envoy.SNIMatch {
+	if len(s) == 0 {
+		return nil
+	}
+
+	matches := make([]*envoy.SNIMatch, 0, len(s))
+	for _, match := range s {
+		matches = append(matches, match.sniMatch)
+	}
+	return matches
+}

--- a/pkg/generator/sni_test.go
+++ b/pkg/generator/sni_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"sort"
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/types"
+	envoy "knative.dev/net-kourier/pkg/envoy/api"
+)
+
+func TestDeduplication(t *testing.T) {
+	s1 := types.NamespacedName{
+		Namespace: "secret-ns-1",
+		Name:      "secret-1",
+	}
+	s2 := types.NamespacedName{
+		Namespace: "secret-ns-2",
+		Name:      "secret-2",
+	}
+
+	tests := []struct {
+		name string
+		in   []*envoy.SNIMatch
+		out  []*envoy.SNIMatch
+	}{{
+		name: "distinct matches",
+		in: []*envoy.SNIMatch{{
+			Hosts:      []string{"foo", "bar"},
+			CertSource: s1,
+		}, {
+			Hosts:      []string{"baz"},
+			CertSource: s2,
+		}},
+		out: []*envoy.SNIMatch{{
+			Hosts:      []string{"foo", "bar"},
+			CertSource: s1,
+		}, {
+			Hosts:      []string{"baz"},
+			CertSource: s2,
+		}},
+	}, {
+		name: "same secret",
+		in: []*envoy.SNIMatch{{
+			Hosts:      []string{"foo", "bar"},
+			CertSource: s1,
+		}, {
+			Hosts:      []string{"baz"},
+			CertSource: s1,
+		}},
+		out: []*envoy.SNIMatch{{
+			Hosts:      []string{"foo", "bar", "baz"},
+			CertSource: s1,
+		}},
+	}, {
+		name: "same secret, one distinct",
+		in: []*envoy.SNIMatch{{
+			Hosts:      []string{"foo", "bar"},
+			CertSource: s1,
+		}, {
+			Hosts:      []string{"baz"},
+			CertSource: s1,
+		}, {
+			Hosts:      []string{"foo2"},
+			CertSource: s2,
+		}, {
+			Hosts:      []string{"bar2"},
+			CertSource: s2,
+		}},
+		out: []*envoy.SNIMatch{{
+			Hosts:      []string{"foo", "bar", "baz"},
+			CertSource: s1,
+		}, {
+			Hosts:      []string{"foo2", "bar2"},
+			CertSource: s2,
+		}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matches := sniMatches{}
+			for _, match := range test.in {
+				matches.consume(match)
+			}
+			got := matches.list()
+
+			// Sort the lists as we go via maps in the implementatio, so the order is
+			// not guaranteed.
+			sort.Slice(test.out, func(i, j int) bool {
+				return test.out[i].CertSource.String() < test.out[j].CertSource.String()
+			})
+			sort.Slice(got, func(i, j int) bool {
+				return got[i].CertSource.String() < got[j].CertSource.String()
+			})
+
+			assert.DeepEqual(t, test.out, matches.list())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #189 

This deduplicates SNIMatches before passing them along the the filter generator. SNIMatches are deduplicated and collapsed based on their certificate source, so the hosts of all SNIMatches that reference the same secret are collapsed into one match and then passed along to the filter as one match too.

/assign @jmprusi @davidor 