### PR TITLE
Remove unused NewRouteStatusOK

### DIFF
--- a/pkg/envoy/api/route.go
+++ b/pkg/envoy/api/route.go
@@ -17,7 +17,6 @@ limitations under the License.
 package envoy
 
 import (
-	"net/http"
 	"time"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -56,20 +55,5 @@ func NewRoute(name string,
 			},
 		},
 		RequestHeadersToAdd: headersToAdd(headers),
-	}
-}
-
-// NewRouteStatusOK creates a route that simply returns 200.
-func NewRouteStatusOK(name string, path string) *route.Route {
-	return &route.Route{
-		Name: name,
-		Match: &route.RouteMatch{
-			PathSpecifier: &route.RouteMatch_Path{
-				Path: path,
-			},
-		},
-		Action: &route.Route_DirectResponse{
-			DirectResponse: &route.DirectResponseAction{Status: http.StatusOK},
-		},
 	}
 }

--- a/pkg/envoy/api/route_test.go
+++ b/pkg/envoy/api/route_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package envoy
 
 import (
-	"net/http"
 	"testing"
 
 	envoy_api_v2_route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -40,14 +39,4 @@ func TestNewRouteHeaderMatch(t *testing.T) {
 	assert.Equal(t, r.Match.Headers[0].Name, "myHeader")
 	assert.Equal(t, r.Match.Headers[0].GetExactMatch(), "strict")
 
-}
-
-func TestNewRouteStatusOK(t *testing.T) {
-	name := "testRoute_12345"
-	path := "/my_route"
-
-	r := NewRouteStatusOK(name, path)
-
-	assert.Equal(t, r.Match.GetPath(), path)
-	assert.Equal(t, r.GetDirectResponse().Status, uint32(http.StatusOK))
 }


### PR DESCRIPTION
This patch removes unused NewRouteStatusOK which creates a route to return 200.
It was not used since e9e16bcbc60b1b3771320164c6606e007576b2cd.

/cc @jmprusi @davidor @markusthoemmes 