### PR TITLE
Fix cluster-cache test to be correct and quicker

### DIFF
--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -66,7 +66,7 @@ func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanu
 
 func (cc *ClustersCache) set(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
 	key := key(cluster.Name, ingressName, ingressNamespace)
-	cc.clusters.Set(key, cluster, gocache.DefaultExpiration)
+	cc.clusters.Set(key, cluster, gocache.NoExpiration)
 }
 
 func (cc *ClustersCache) setExpiration(clusterName string, ingressName string, ingressNamespace string) {

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -46,13 +46,13 @@ import (
 )
 
 const (
-	clusterExpiration      = 15 * time.Second
-	defaultExpiration      = gocache.NoExpiration
+	defaultExpiration      = 15 * time.Second
 	defaultCleanupInterval = 1 * time.Minute
 )
 
 type ClustersCache struct {
-	clusters *gocache.Cache
+	clusterExpiration time.Duration
+	clusters          *gocache.Cache
 }
 
 func newClustersCache() *ClustersCache {
@@ -60,19 +60,19 @@ func newClustersCache() *ClustersCache {
 }
 
 func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanupInterval time.Duration) *ClustersCache {
-	goCache := gocache.New(expiration, cleanupInterval)
-	return &ClustersCache{clusters: goCache}
+	goCache := gocache.New(gocache.NoExpiration, cleanupInterval)
+	return &ClustersCache{clusters: goCache, clusterExpiration: expiration}
 }
 
 func (cc *ClustersCache) set(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
 	key := key(cluster.Name, ingressName, ingressNamespace)
-	cc.clusters.Set(key, cluster, defaultExpiration)
+	cc.clusters.Set(key, cluster, gocache.DefaultExpiration)
 }
 
 func (cc *ClustersCache) setExpiration(clusterName string, ingressName string, ingressNamespace string) {
 	key := key(clusterName, ingressName, ingressNamespace)
 	if cluster, ok := cc.clusters.Get(key); ok {
-		cc.clusters.Set(key, cluster, clusterExpiration)
+		cc.clusters.Set(key, cluster, cc.clusterExpiration)
 	}
 }
 


### PR DESCRIPTION
The cluster cache test currently does not test what we actually want to test. It instead uses a parameter that will never be set in production.

This fixes that and also makes the test considerably quicker. It used to take 2 seconds for no apparent reason.

/assign @jmprusi @davidor 