### PR TITLE
Generate listers and routes when actually needed and don't 'cache' them

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -20,17 +20,30 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"knative.dev/net-kourier/pkg/config"
+	envoy "knative.dev/net-kourier/pkg/envoy/api"
+)
+
+const (
+	envCertsSecretNamespace = "CERTS_SECRET_NAMESPACE"
+	envCertsSecretName      = "CERTS_SECRET_NAME"
+	certFieldInSecret       = "tls.crt"
+	keyFieldInSecret        = "tls.key"
+	externalRouteConfigName = "external_services"
+	internalRouteConfigName = "internal_services"
 )
 
 var ErrDomainConflict = errors.New("ingress has a conflicting domain with another ingress")
@@ -230,4 +243,80 @@ func (caches *Caches) getNewSnapshotVersion() (string, error) {
 	}
 
 	return snapshotVersion.String(), nil
+}
+
+func listenersFromVirtualHosts(
+	ctx context.Context,
+	externalVirtualHosts []*route.VirtualHost,
+	clusterLocalVirtualHosts []*route.VirtualHost,
+	sniMatches []*envoy.SNIMatch,
+	kubeclient kubeclient.Interface,
+	caches *Caches) ([]*v2.Listener, error) {
+
+	// First, we save the RouteConfigs with the proper name and all the virtualhosts etc. into the cache.
+	externalRouteConfig := envoy.NewRouteConfig(externalRouteConfigName, externalVirtualHosts)
+	internalRouteConfig := envoy.NewRouteConfig(internalRouteConfigName, clusterLocalVirtualHosts)
+	caches.routeConfig = []*v2.RouteConfiguration{externalRouteConfig, internalRouteConfig}
+
+	// Now we setup connection managers, that reference the routeconfigs via RDS.
+	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name)
+	internalManager := envoy.NewHTTPConnectionManager(internalRouteConfig.Name)
+	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal)
+	if err != nil {
+		return nil, err
+	}
+	internalEnvoyListener, err := envoy.NewHTTPListener(internalManager, config.HTTPPortInternal)
+	if err != nil {
+		return nil, err
+	}
+
+	listeners := []*v2.Listener{externalHTTPEnvoyListener, internalEnvoyListener}
+
+	// Configure TLS Listener. If there's at least one ingress that contains the
+	// TLS field, that takes precedence. If there is not, TLS will be configured
+	// using a single cert for all the services if the creds are given via ENV.
+	if len(sniMatches) > 0 {
+		externalHTTPSEnvoyListener, err := envoy.NewHTTPSListenerWithSNI(externalManager, config.HTTPSPortExternal, sniMatches)
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, externalHTTPSEnvoyListener)
+	} else if useHTTPSListenerWithOneCert() {
+		externalHTTPSEnvoyListener, err := newExternalEnvoyListenerWithOneCert(
+			ctx, externalManager, kubeclient,
+		)
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, externalHTTPSEnvoyListener)
+	}
+
+	return listeners, nil
+}
+
+// Returns true if we need to modify the HTTPS listener with just one cert
+// instead of one per ingress
+func useHTTPSListenerWithOneCert() bool {
+	return os.Getenv(envCertsSecretNamespace) != "" &&
+		os.Getenv(envCertsSecretName) != ""
+}
+
+func sslCreds(ctx context.Context, kubeClient kubeclient.Interface, secretNamespace string, secretName string) (certificateChain []byte, privateKey []byte, err error) {
+	secret, err := kubeClient.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return secret.Data[certFieldInSecret], secret.Data[keyFieldInSecret], nil
+}
+
+func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnmanagerv2.HttpConnectionManager, kubeClient kubeclient.Interface) (*v2.Listener, error) {
+	certificateChain, privateKey, err := sslCreds(
+		ctx, kubeClient, os.Getenv(envCertsSecretNamespace), os.Getenv(envCertsSecretName),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return envoy.NewHTTPSListener(manager, config.HTTPSPortExternal, certificateChain, privateKey)
 }

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -44,7 +44,6 @@ func TestDeleteIngressInfo(t *testing.T) {
 	firstIngressName := "ingress_1"
 	firstIngressNamespace := "ingress_1_namespace"
 	createTestDataForIngress(
-		ctx,
 		caches,
 		firstIngressName,
 		firstIngressNamespace,
@@ -57,7 +56,6 @@ func TestDeleteIngressInfo(t *testing.T) {
 	secondIngressName := "ingress_2"
 	secondIngressNamespace := "ingress_2_namespace"
 	createTestDataForIngress(
-		ctx,
 		caches,
 		secondIngressName,
 		secondIngressNamespace,
@@ -109,7 +107,6 @@ func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 	firstIngressName := "ingress_1"
 	firstIngressNamespace := "ingress_1_namespace"
 	createTestDataForIngress(
-		ctx,
 		caches,
 		firstIngressName,
 		firstIngressNamespace,
@@ -154,7 +151,6 @@ func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 // Creates an ingress translation and listeners from the given names an
 // associates them with the ingress name/namespace received.
 func createTestDataForIngress(
-	ctx context.Context,
 	caches *Caches,
 	ingressName string,
 	ingressNamespace string,
@@ -183,7 +179,6 @@ func TestValidateIngress(t *testing.T) {
 	assert.NilError(t, err)
 
 	createTestDataForIngress(
-		ctx,
 		caches,
 		"ingress_1",
 		"ingress_1_namespace",

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -19,27 +19,9 @@ package generator
 import (
 	"context"
 	"fmt"
-	"os"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeclient "k8s.io/client-go/kubernetes"
-
-	"knative.dev/net-kourier/pkg/config"
-	envoy "knative.dev/net-kourier/pkg/envoy/api"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/ingress"
-)
-
-const (
-	envCertsSecretNamespace = "CERTS_SECRET_NAMESPACE"
-	envCertsSecretName      = "CERTS_SECRET_NAME"
-	certFieldInSecret       = "tls.crt"
-	keyFieldInSecret        = "tls.key"
-	externalRouteConfigName = "external_services"
-	internalRouteConfigName = "internal_services"
 )
 
 // For now, when updating the info for an ingress we delete it, and then
@@ -61,80 +43,4 @@ func UpdateInfoForIngress(ctx context.Context, caches *Caches, ing *v1alpha1.Ing
 	}
 
 	return caches.UpdateIngress(ctx, ingressTranslation)
-}
-
-func listenersFromVirtualHosts(
-	ctx context.Context,
-	externalVirtualHosts []*route.VirtualHost,
-	clusterLocalVirtualHosts []*route.VirtualHost,
-	sniMatches []*envoy.SNIMatch,
-	kubeclient kubeclient.Interface,
-	caches *Caches) ([]*v2.Listener, error) {
-
-	// First, we save the RouteConfigs with the proper name and all the virtualhosts etc. into the cache.
-	externalRouteConfig := envoy.NewRouteConfig(externalRouteConfigName, externalVirtualHosts)
-	internalRouteConfig := envoy.NewRouteConfig(internalRouteConfigName, clusterLocalVirtualHosts)
-	caches.routeConfig = []*v2.RouteConfiguration{externalRouteConfig, internalRouteConfig}
-
-	// Now we setup connection managers, that reference the routeconfigs via RDS.
-	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name)
-	internalManager := envoy.NewHTTPConnectionManager(internalRouteConfig.Name)
-	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal)
-	if err != nil {
-		return nil, err
-	}
-	internalEnvoyListener, err := envoy.NewHTTPListener(internalManager, config.HTTPPortInternal)
-	if err != nil {
-		return nil, err
-	}
-
-	listeners := []*v2.Listener{externalHTTPEnvoyListener, internalEnvoyListener}
-
-	// Configure TLS Listener. If there's at least one ingress that contains the
-	// TLS field, that takes precedence. If there is not, TLS will be configured
-	// using a single cert for all the services if the creds are given via ENV.
-	if len(sniMatches) > 0 {
-		externalHTTPSEnvoyListener, err := envoy.NewHTTPSListenerWithSNI(externalManager, config.HTTPSPortExternal, sniMatches)
-		if err != nil {
-			return nil, err
-		}
-		listeners = append(listeners, externalHTTPSEnvoyListener)
-	} else if useHTTPSListenerWithOneCert() {
-		externalHTTPSEnvoyListener, err := newExternalEnvoyListenerWithOneCert(
-			ctx, externalManager, kubeclient,
-		)
-		if err != nil {
-			return nil, err
-		}
-		listeners = append(listeners, externalHTTPSEnvoyListener)
-	}
-
-	return listeners, nil
-}
-
-// Returns true if we need to modify the HTTPS listener with just one cert
-// instead of one per ingress
-func useHTTPSListenerWithOneCert() bool {
-	return os.Getenv(envCertsSecretNamespace) != "" &&
-		os.Getenv(envCertsSecretName) != ""
-}
-
-func sslCreds(ctx context.Context, kubeClient kubeclient.Interface, secretNamespace string, secretName string) (certificateChain []byte, privateKey []byte, err error) {
-	secret, err := kubeClient.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return secret.Data[certFieldInSecret], secret.Data[keyFieldInSecret], nil
-}
-
-func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnmanagerv2.HttpConnectionManager, kubeClient kubeclient.Interface) (*v2.Listener, error) {
-	certificateChain, privateKey, err := sslCreds(
-		ctx, kubeClient, os.Getenv(envCertsSecretNamespace), os.Getenv(envCertsSecretName),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return envoy.NewHTTPSListener(manager, config.HTTPSPortExternal, certificateChain, privateKey)
 }

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -130,7 +130,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	r.ingressTranslator = &ingressTranslator
 
 	// Initialize the Envoy snapshot.
-	snapshot, err := r.caches.ToEnvoySnapshot()
+	snapshot, err := r.caches.ToEnvoySnapshot(ctx)
 	if err != nil {
 		logger.Fatalw("Failed to create snapshot", zap.Error(err))
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -126,7 +126,7 @@ func (r *Reconciler) updateEnvoyConfig(ctx context.Context) error {
 	}
 
 	logger.Debugf("Preparing Envoy Snapshot")
-	newSnapshot, err := r.caches.ToEnvoySnapshot()
+	newSnapshot, err := r.caches.ToEnvoySnapshot(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This refactors the `setListeners` method out of the cache. Unless I'm misreading things, it didn't actually do anything useful other than obstructing the code-path regarding when and how often listeners are computed. If I'm not missing something, this shouldn't change anything in behavior.

/assign @jmprusi @davidor 