### PR TITLE
Cleanup functions around getting/setting snapshots

### DIFF
--- a/pkg/envoy/server/xds_server.go
+++ b/pkg/envoy/server/xds_server.go
@@ -97,10 +97,6 @@ func (envoyXdsServer *XdsServer) RunManagementServer() error {
 	}
 }
 
-func (envoyXdsServer *XdsServer) GetSnapshot(nodeid string) (cache.Snapshot, error) {
-	return envoyXdsServer.snapshotCache.GetSnapshot(nodeid)
-}
-
-func (envoyXdsServer *XdsServer) SetSnapshot(snapshot *cache.Snapshot, nodeID string) error {
-	return envoyXdsServer.snapshotCache.SetSnapshot(nodeID, *snapshot)
+func (envoyXdsServer *XdsServer) SetSnapshot(nodeID string, snapshot cache.Snapshot) error {
+	return envoyXdsServer.snapshotCache.SetSnapshot(nodeID, snapshot)
 }

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -134,7 +134,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	if err != nil {
 		logger.Fatalw("Failed to create snapshot", zap.Error(err))
 	}
-	err = r.xdsServer.SetSnapshot(&snapshot, nodeID)
+	err = r.xdsServer.SetSnapshot(nodeID, snapshot)
 	if err != nil {
 		logger.Fatalw("Failed to set snapshot", zap.Error(err))
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -125,5 +125,5 @@ func (r *Reconciler) updateEnvoyConfig(ctx context.Context) error {
 		return err
 	}
 
-	return r.xdsServer.SetSnapshot(&newSnapshot, nodeID)
+	return r.xdsServer.SetSnapshot(nodeID, newSnapshot)
 }


### PR DESCRIPTION
- `GetSnapshot` isn't used anymore at all.
- `SetSnapshot` doesn't have to take a pointer just to dereference it again to pass it on.
- Copied the order from envoy types.

/assign @jmprusi @davidor 