### PR TITLE
Bump envoy version to 1.14.4

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -35,7 +35,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/maistra/proxyv2-ubi8:1.1.5
+          image: docker.io/maistra/proxyv2-ubi8:2.0.0
           name: kourier-gateway
           ports:
             - name: http2-external
@@ -156,7 +156,9 @@ data:
                             - "*"
                           routes:
                             - match:
-                                regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                safe_regex:
+                                  google_re2: {}
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
                                 headers:
                                   - name: ':method'
                                     exact_match: GET


### PR DESCRIPTION
As per title. This bumps the image to Maistra's 2.0.0 image, which has envoy 1.14.4.

The regex configuration got dropped and replaced as shown.

/assign @jmprusi @davidor 