### PR TITLE
Fix all deprecation warnings from Envoy

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -146,9 +146,12 @@ data:
               port_value: 9000
           filter_chains:
             - filters:
-                - name: envoy.http_connection_manager
-                  config:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: stats_server
+                    http_filters:
+                      - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:
                         - name: admin_interface
@@ -164,9 +167,6 @@ data:
                                     exact_match: GET
                               route:
                                 cluster: service_stats
-                    http_filters:
-                      - name: envoy.router
-                        config: {}
       clusters:
         - name: service_stats
           connect_timeout: 0.250s
@@ -181,10 +181,16 @@ data:
                       path: /tmp/envoy.admin
         - name: xds_cluster
           connect_timeout: 1s
-          hosts:
-            - socket_address:
-                address: "kourier-control.knative-serving"
-                port_value: 18000
+          type: strict_dns
+          load_assignment:
+            cluster_name: xds_cluster
+            endpoints:
+              lb_endpoints:
+                endpoint:
+                  address:
+                    socket_address:
+                      address: "kourier-control.knative-serving"
+                      port_value: 18000
           http2_protocol_options: {}
           type: STRICT_DNS
     admin:

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -27,7 +27,6 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/conversion"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/kelseyhightower/envconfig"
@@ -138,15 +137,15 @@ func externalAuthZFilter(clusterName string, timeout time.Duration, failureModeA
 		ClearRouteCache: false,
 	}
 
-	envoyConf, err := conversion.MessageToStruct(extAuthConfig)
+	envoyConf, err := ptypes.MarshalAny(extAuthConfig)
 	if err != nil {
 		panic(err)
 	}
 
 	return &httpconnectionmanagerv2.HttpFilter{
 		Name: wellknown.HTTPExternalAuthorization,
-		ConfigType: &httpconnectionmanagerv2.HttpFilter_Config{
-			Config: envoyConf,
+		ConfigType: &httpconnectionmanagerv2.HttpFilter_TypedConfig{
+			TypedConfig: envoyConf,
 		},
 	}
 }


### PR DESCRIPTION
Further future proofing for upcoming Envoy updates. This fixes all current deprecation warnings we're getting from Envoy.

/assign @jmprusi @davidor 