### PR TITLE
Use Any machinery to construct TypedConfigs everywhere

### DIFF
--- a/pkg/envoy/api/virtual_host.go
+++ b/pkg/envoy/api/virtual_host.go
@@ -20,7 +20,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/proto" //nolint // TODO: Move over to non-deprecated proto package
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 )
 
@@ -40,21 +40,13 @@ func NewVirtualHostWithExtAuthz(
 	domains []string,
 	routes []*route.Route) *route.VirtualHost {
 
-	perFilterConfig := extAuthService.ExtAuthzPerRoute{
+	filter, _ := ptypes.MarshalAny(&extAuthService.ExtAuthzPerRoute{
 		Override: &extAuthService.ExtAuthzPerRoute_CheckSettings{
 			CheckSettings: &extAuthService.CheckSettings{
 				ContextExtensions: contextExtensions,
 			},
 		},
-	}
-
-	b := proto.NewBuffer(nil)
-	b.SetDeterministic(true)
-	_ = b.Marshal(&perFilterConfig)
-	filter := &any.Any{
-		TypeUrl: "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute",
-		Value:   b.Bytes(),
-	}
+	})
 
 	return &route.VirtualHost{
 		Name:    name,

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -22,7 +22,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/proto" //nolint // TODO: Move over to non-deprecated proto package
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"knative.dev/net-kourier/pkg/config"
 	envoy "knative.dev/net-kourier/pkg/envoy/api"
@@ -38,20 +38,11 @@ func statusVHost() *route.VirtualHost {
 	)
 
 	// Make sure that ExtAuthz configuration is ignored on this path.
-	perFilterConfig := extAuthService.ExtAuthzPerRoute{
+	filter, _ := ptypes.MarshalAny(&extAuthService.ExtAuthzPerRoute{
 		Override: &extAuthService.ExtAuthzPerRoute_Disabled{
 			Disabled: true,
 		},
-	}
-
-	b := proto.NewBuffer(nil)
-	b.SetDeterministic(true)
-	b.Marshal(&perFilterConfig)
-
-	filter := &any.Any{
-		TypeUrl: "type.googleapis.com/envoy.config.filter.http.ext_authz.v2.ExtAuthzPerRoute",
-		Value:   b.Bytes(),
-	}
+	})
 
 	vhost.TypedPerFilterConfig = map[string]*any.Any{
 		wellknown.HTTPExternalAuthorization: filter,


### PR DESCRIPTION
As per title, this aligns all occurrences of constructing a `TypedConfig` by using specific `Any` marshalling machinery. Easier and more consistent.

/assign @jmprusi @davidor 