### PR TITLE
Don't even try to probe services that have a domain conflict

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -155,7 +155,7 @@ jobs:
         IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 
         # Run conformance tests.
-        go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... \
+        go test -race -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... ./test/e2e/... \
            --enable-alpha --enable-beta \
            --ingressendpoint="${IPS[0]}" \
            --ingressClass=kourier.ingress.networking.knative.dev \

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -51,8 +51,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 	if err := r.updateIngress(ctx, ing); errors.Is(err, generator.ErrDomainConflict) {
 		// If we had an error due to a duplicated domain, we must mark the ingress as failed with a
 		// custom status. We don't want to return an error in this case as we want to update its status.
-		logging.FromContext(ctx).Info("Ingress rejected as its domain conflicts with another ingress")
-		ing.Status.MarkLoadBalancerFailed("DomainConflict", "Ingress rejected as its domain conflicts with another ingress")
+		logging.FromContext(ctx).Info(err.Error())
+		ing.Status.MarkLoadBalancerFailed("DomainConflict", "Ingress rejected: "+err.Error())
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to update ingress: %w", err)
@@ -83,7 +83,7 @@ func (r *Reconciler) ObserveKind(ctx context.Context, ing *v1alpha1.Ingress) rec
 
 	if err := r.updateIngress(ctx, ing); errors.Is(err, generator.ErrDomainConflict) {
 		// If we had an error due to a duplicated domain, just abort.
-		logging.FromContext(ctx).Info("Ingress rejected as its domain conflicts with another ingress")
+		logging.FromContext(ctx).Info(err.Error())
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to update ingress: %w", err)

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -34,7 +34,7 @@ export "GATEWAY_OVERRIDE=kourier"
 export "GATEWAY_NAMESPACE_OVERRIDE=${KOURIER_GATEWAY_NAMESPACE}"
 
 echo ">> Running conformance tests"
-go test -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... \
+go test -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... ./test/e2e/... \
   --enable-alpha --enable-beta \
   --ingressendpoint="${ips[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,6 +23,7 @@ failed=0
 
 go_test_e2e -timeout=20m -parallel=12 \
   ./test/conformance \
+  ./test/e2e/ \
   --enable-alpha --enable-beta \
   --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 

--- a/test/e2e/conflict_test.go
+++ b/test/e2e/conflict_test.go
@@ -1,0 +1,72 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/test"
+	"knative.dev/networking/test/conformance/ingress"
+)
+
+func TestConflictingDomains(t *testing.T) {
+	clients := test.Setup(t)
+	ctx := context.Background()
+
+	name, port, _ := ingress.CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
+
+	spec := v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	}
+
+	// The first ingress should become ready just fine.
+	ingress.CreateIngressReady(ctx, t, clients, spec)
+
+	// The second one with the same spec is supposed to throw a conflict error.
+	ing, _ := ingress.CreateIngress(ctx, t, clients, spec)
+	if err := ingress.WaitForIngressState(
+		ctx,
+		clients.NetworkingClient,
+		ing.Name,
+		func(r *v1alpha1.Ingress) (bool, error) {
+			return r.GetStatus().GetCondition(v1alpha1.IngressConditionLoadBalancerReady).GetReason() == "DomainConflict", nil
+		},
+		t.Name()); err != nil {
+		t.Fatalf("Error waiting for ingress %q state: %v", ing.Name, err)
+	}
+
+}


### PR DESCRIPTION
During translation to the new reconciler framework, we lost the ability to surface domain conflicts from the reconciler because we're not bailing out of reconcilation before we reach the prober, which will reset to `MarkLoadBalancerNotReady`. This fixes that.

This also drops the loglevel of the conflict log to info, as it's not really an error from the reconciler's PoV.

/assign @jmprusi @davidor 