### PR TITLE
Remove unused EnvoyNodeID value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,8 +26,6 @@ import (
 const (
 	ControllerName = "kourier"
 
-	EnvoyNodeID = "3scale-kourier-gateway"
-
 	InternalServiceName = "kourier-internal"
 	ExternalServiceName = "kourier"
 


### PR DESCRIPTION
This patch makes a tiny change which removes unused `EnvoyNodeID` value.

The node ID is defined as `nodeID` in [controller.go](https://github.com/knative-sandbox/net-kourier/blob/42e7f0fbf7337c4d50af790b2ef9dad4a6557026/pkg/reconciler/ingress/controller.go#L56).

# Changes

/kind cleanup

**Release Note**

```release-note
NONE
```
