### PR TITLE
Publish multi-arch images

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,7 +47,7 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative net-kourier - ${config}"
-    ko resolve --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    ko resolve --strict --platform=all ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" >> ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -37,11 +37,11 @@ function test_setup() {
   echo ">> Publishing test images"
   $(dirname $0)/upload-test-images.sh || fail_test "Error uploading test images"
   echo ">> Creating test resources (test/config/)"
-  ko apply ${KO_FLAGS} -f test/config/ || return 1
+  ko apply --platform=all ${KO_FLAGS} -f test/config/ || return 1
 
   # Bringing up controllers.
   echo ">> Bringing up Kourier"
-  ko resolve -f config | sed 's/--log-level info/--log-level debug/g' | ko apply -f - || return 1
+  ko resolve --platform=all -f config | sed 's/--log-level info/--log-level debug/g' | kubectl apply -f - || return 1
 
   scale_deployment 3scale-kourier-control "${KOURIER_CONTROL_NAMESPACE}"
   scale_deployment 3scale-kourier-gateway "${GATEWAY_NAMESPACE_OVERRIDE}"

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -33,7 +33,7 @@ function upload_test_images() {
       sed "s@knative.dev/networking@knative.dev/net-kourier/vendor/knative.dev/networking@g" $yaml \
         `# ko resolve is being used for the side-effect of publishing images,` \
         `# so the resulting yaml produced is ignored.` \
-        | ko resolve ${tag_option} -RBf- > /dev/null
+        | ko resolve --platform=all ${tag_option} -RBf- > /dev/null
     done
   )
 }


### PR DESCRIPTION
# Changes

Buid images for all the platforms ko supports.

This is same enhancement with https://github.com/knative-sandbox/net-istio/pull/431 and https://github.com/knative-sandbox/net-contour/pull/285.

/kind enhancement

Fixes https://github.com/knative-sandbox/net-kourier/issues/405

**Release Note**

```release-note
Images are now multi-platform and support architectures such as `arm64`.
```

