### PR TITLE
Use generic envoy image by default but keep testing Maistra

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -29,7 +29,7 @@ jobs:
 
         gateway:
         - docker.io/maistra/proxyv2-ubi8:2.0.0
-        - docker.io/envoyproxy/envoy:v1.16.2
+        - docker.io/envoyproxy/envoy:v1.16-latest
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
@@ -130,7 +130,7 @@ jobs:
         export GOFLAGS=-mod=vendor
         ko resolve -f test/config/ -f config/ | \
           sed 's/LoadBalancer/NodePort/g' | \
-          sed "s|docker.io/maistra/proxyv2-ubi8:.*|${{ matrix.gateway }}|" | \
+          sed "s|docker.io/envoyproxy/envoy:.*|${{ matrix.gateway }}|" | \
           kubectl apply -f -
 
         # This tells the tests what namespace to look in for our kingress LB.

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -36,7 +36,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/maistra/proxyv2-ubi8:2.0.0
+          image: docker.io/envoyproxy/envoy:v1.16-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
This makes "upstream" more generic while still making sure that net-kourier still works fine with Maistra's images.