### PR TITLE
set alpn protocols to h2,http/1.1 on downstream tls context

### DIFF
--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -170,9 +170,6 @@ func createTLSContext(certificate []byte, privateKey []byte) *auth.DownstreamTls
 	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			AlpnProtocols: []string{"h2", "http/1.1"},
-			//TlsParams: &auth.TlsParameters{
-			//	TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
-			//},
 			TlsCertificates: []*auth.TlsCertificate{{
 				CertificateChain: &core.DataSource{
 					Specifier: &core.DataSource_InlineBytes{InlineBytes: certificate},

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -169,6 +169,10 @@ func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, 
 func createTLSContext(certificate []byte, privateKey []byte) *auth.DownstreamTlsContext {
 	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
+			AlpnProtocols: []string{"h2", "http/1.1"},
+			//TlsParams: &auth.TlsParameters{
+			//	TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+			//},
 			TlsCertificates: []*auth.TlsCertificate{{
 				CertificateChain: &core.DataSource{
 					Specifier: &core.DataSource_InlineBytes{InlineBytes: certificate},


### PR DESCRIPTION
# Changes
- :broom: Set alpn protocols on downstream tls context, in order to leverage h2.

/kind enhancement