### PR TITLE
Simplify gateway config

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -36,35 +36,6 @@ data:
       cluster: kourier-knative
       id: 3scale-kourier-gateway
     static_resources:
-      listeners:
-        - name: stats_listener
-          address:
-            socket_address:
-              address: 0.0.0.0
-              port_value: 9000
-          filter_chains:
-            - filters:
-                - name: envoy.filters.network.http_connection_manager
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                    stat_prefix: stats_server
-                    http_filters:
-                      - name: envoy.filters.http.router
-                    route_config:
-                      virtual_hosts:
-                        - name: admin_interface
-                          domains:
-                            - "*"
-                          routes:
-                            - match:
-                                safe_regex:
-                                  google_re2: {}
-                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
-                                headers:
-                                  - name: ':method'
-                                    exact_match: GET
-                              route:
-                                cluster: service_stats
       clusters:
         - name: service_stats
           connect_timeout: 0.250s

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -61,7 +61,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh","-c","curl -X POST --unix /tmp/envoy.admin http://localhost/healthcheck/fail; sleep 15"]
+                command: ["/bin/sh","-c","sleep 15"]
           readinessProbe:
             httpGet:
               httpHeaders:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

1. Remove calling the internal admin endpoint and failing the health
   check. That doesn't seem to be necessary seeing as K8s will consider
   the pod failed as soon as it receives the deletion signal. The 15s
   wait alone should be fine.
2. Drop the stats listener. The port exposed port isn't used anywhere
   anyway.

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Simplified the gateway configuration.
```
