### PR TITLE
Drop usage of outdated protobuf module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad
-	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -29,8 +29,9 @@ import (
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/kelseyhightower/envconfig"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -96,7 +97,7 @@ func extAuthzCluster(host string, port uint32) *v2.Cluster {
 			Type: v2.Cluster_STRICT_DNS,
 		},
 		Http2ProtocolOptions: &core.Http2ProtocolOptions{},
-		ConnectTimeout:       ptypes.DurationProto(5 * time.Second),
+		ConnectTimeout:       durationpb.New(5 * time.Second),
 		LoadAssignment: &v2.ClusterLoadAssignment{
 			ClusterName: extAuthzClusterName,
 			Endpoints: []*endpoint.LocalityLbEndpoints{{
@@ -132,7 +133,7 @@ func externalAuthZFilter(clusterName string, timeout time.Duration, failureModeA
 						ClusterName: clusterName,
 					},
 				},
-				Timeout: ptypes.DurationProto(timeout),
+				Timeout: durationpb.New(timeout),
 				InitialMetadata: []*core.HeaderValue{{
 					Key:   "client",
 					Value: "kourier",
@@ -147,7 +148,7 @@ func externalAuthZFilter(clusterName string, timeout time.Duration, failureModeA
 		ClearRouteCache: false,
 	}
 
-	envoyConf, err := ptypes.MarshalAny(extAuthConfig)
+	envoyConf, err := anypb.New(extAuthConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/envoy/api/cluster.go
+++ b/pkg/envoy/api/cluster.go
@@ -22,7 +22,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // NewCluster generates a new v2.Cluster with the given settings.
@@ -38,7 +38,7 @@ func NewCluster(
 		ClusterDiscoveryType: &v2.Cluster_Type{
 			Type: discoveryType,
 		},
-		ConnectTimeout: ptypes.DurationProto(connectTimeout),
+		ConnectTimeout: durationpb.New(connectTimeout),
 		LoadAssignment: &v2.ClusterLoadAssignment{
 			ClusterName: name,
 			Endpoints: []*endpoint.LocalityLbEndpoints{{

--- a/pkg/envoy/api/headers.go
+++ b/pkg/envoy/api/headers.go
@@ -18,7 +18,7 @@ package envoy
 
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // headersToAdd generates a list of HeaderValueOption from a map of headers.
@@ -34,11 +34,9 @@ func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
 				Key:   headerName,
 				Value: headerVal,
 			},
-			Append: &wrappers.BoolValue{
-				// In Knative Serving, headers are set instead of appended.
-				// Ref: https://github.com/knative/serving/pull/6366
-				Value: false,
-			},
+			// In Knative Serving, headers are set instead of appended.
+			// Ref: https://github.com/knative/serving/pull/6366
+			Append: wrapperspb.Bool(false),
 		})
 	}
 

--- a/pkg/envoy/api/headers_test.go
+++ b/pkg/envoy/api/headers_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"gotest.tools/v3/assert"
 )
 
@@ -50,17 +50,13 @@ func TestHeadersToAdd(t *testing.T) {
 				Key:   "foo",
 				Value: "bar",
 			},
-			Append: &wrappers.BoolValue{
-				Value: false,
-			},
+			Append: wrapperspb.Bool(false),
 		}, {
 			Header: &core.HeaderValue{
 				Key:   "baz",
 				Value: "lol",
 			},
-			Append: &wrappers.BoolValue{
-				Value: false,
-			},
+			Append: wrapperspb.Bool(false),
 		}},
 	}}
 

--- a/pkg/envoy/api/http_connection_manager.go
+++ b/pkg/envoy/api/http_connection_manager.go
@@ -17,6 +17,8 @@ limitations under the License.
 package envoy
 
 import (
+	"time"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -24,8 +26,9 @@ import (
 	envoy_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/duration"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	"knative.dev/net-kourier/pkg/config"
 )
 
@@ -44,7 +47,7 @@ func NewHTTPConnectionManager(routeConfigName string) *httpconnectionmanagerv2.H
 	})
 
 	// Write access logs to stdout by default.
-	accessLog, _ := ptypes.MarshalAny(&accesslog_v2.FileAccessLog{
+	accessLog, _ := anypb.New(&accesslog_v2.FileAccessLog{
 		Path: "/dev/stdout",
 	})
 
@@ -64,10 +67,7 @@ func NewHTTPConnectionManager(routeConfigName string) *httpconnectionmanagerv2.H
 					ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
 						Ads: &envoy_api_v2_core.AggregatedConfigSource{},
 					},
-					InitialFetchTimeout: &duration.Duration{
-						Seconds: 10,
-						Nanos:   0,
-					},
+					InitialFetchTimeout: durationpb.New(10 * time.Second),
 				},
 				RouteConfigName: routeConfigName,
 			},

--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -23,8 +23,9 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	envoy_config_filter_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 	"gotest.tools/v3/assert"
 )
 
@@ -34,7 +35,7 @@ func TestNewHTTPConnectionManager(t *testing.T) {
 	accessLogPathAny := accessLog.ConfigType.(*envoy_config_filter_accesslog_v2.AccessLog_TypedConfig).TypedConfig
 	fileAccesLog := &accesslog_v2.FileAccessLog{}
 
-	err := ptypes.UnmarshalAny(accessLogPathAny, fileAccesLog)
+	err := anypb.UnmarshalTo(accessLogPathAny, fileAccesLog, proto.UnmarshalOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -25,7 +25,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -68,7 +68,7 @@ func NewHTTPSListener(
 	}
 
 	tlsContext := createTLSContext(certificateChain, privateKey)
-	tlsAny, err := ptypes.MarshalAny(tlsContext)
+	tlsAny, err := anypb.New(tlsContext)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func createAddress(port uint32) *core.Address {
 }
 
 func createFilters(manager *httpconnmanagerv2.HttpConnectionManager) ([]*listener.Filter, error) {
-	managerAny, err := ptypes.MarshalAny(manager)
+	managerAny, err := anypb.New(manager)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, 
 		}
 
 		tlsContext := createTLSContext(sniMatch.CertificateChain, sniMatch.PrivateKey)
-		tlsAny, err := ptypes.MarshalAny(tlsContext)
+		tlsAny, err := anypb.New(tlsContext)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -26,7 +26,8 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -115,9 +116,7 @@ func getFilterChainByServerName(listener *envoy_api_v2.Listener, serverNames []s
 // Note: Returns an error when there are multiple certificates
 func getTLSCreds(filterChain *envoy_api_v2_listener.FilterChain) (certChain []byte, privateKey []byte, err error) {
 	downstreamTLSContext := &auth.DownstreamTlsContext{}
-	err = ptypes.UnmarshalAny(
-		filterChain.GetTransportSocket().GetTypedConfig(), downstreamTLSContext,
-	)
+	err = anypb.UnmarshalTo(filterChain.GetTransportSocket().GetTypedConfig(), downstreamTLSContext, proto.UnmarshalOptions{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/envoy/api/route.go
+++ b/pkg/envoy/api/route.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // NewRoute creates a new Route.
@@ -39,10 +39,10 @@ func NewRoute(name string,
 				Clusters: wrs,
 			},
 		},
-		Timeout: ptypes.DurationProto(routeTimeout),
+		Timeout: durationpb.New(routeTimeout),
 		UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
 			UpgradeType: "websocket",
-			Enabled:     &wrappers.BoolValue{Value: true},
+			Enabled:     wrapperspb.Bool(true),
 		}},
 	}
 

--- a/pkg/envoy/api/virtual_host.go
+++ b/pkg/envoy/api/virtual_host.go
@@ -20,8 +20,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // NewVirtualHost creates a new VirtualHost.
@@ -40,7 +39,7 @@ func NewVirtualHostWithExtAuthz(
 	domains []string,
 	routes []*route.Route) *route.VirtualHost {
 
-	filter, _ := ptypes.MarshalAny(&extAuthService.ExtAuthzPerRoute{
+	filter, _ := anypb.New(&extAuthService.ExtAuthzPerRoute{
 		Override: &extAuthService.ExtAuthzPerRoute_CheckSettings{
 			CheckSettings: &extAuthService.CheckSettings{
 				ContextExtensions: contextExtensions,
@@ -52,7 +51,7 @@ func NewVirtualHostWithExtAuthz(
 		Name:    name,
 		Domains: domains,
 		Routes:  routes,
-		TypedPerFilterConfig: map[string]*any.Any{
+		TypedPerFilterConfig: map[string]*anypb.Any{
 			wellknown.HTTPExternalAuthorization: filter,
 		},
 	}

--- a/pkg/envoy/api/weighted_cluster.go
+++ b/pkg/envoy/api/weighted_cluster.go
@@ -18,16 +18,14 @@ package envoy
 
 import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // NewWeightedCluster creates a new WeightedCluster.
 func NewWeightedCluster(name string, trafficPerc uint32, headers map[string]string) *route.WeightedCluster_ClusterWeight {
 	return &route.WeightedCluster_ClusterWeight{
-		Name: name,
-		Weight: &wrappers.UInt32Value{
-			Value: trafficPerc,
-		},
+		Name:                name,
+		Weight:              wrapperspb.UInt32(trafficPerc),
 		RequestHeadersToAdd: headersToAdd(headers),
 	}
 }

--- a/pkg/envoy/api/weighted_cluster_test.go
+++ b/pkg/envoy/api/weighted_cluster_test.go
@@ -21,8 +21,8 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"gotest.tools/v3/assert"
 )
 
@@ -31,18 +31,14 @@ func TestNewWeightedCluster(t *testing.T) {
 		"foo": "bar",
 	})
 	want := &route.WeightedCluster_ClusterWeight{
-		Name: "test",
-		Weight: &wrappers.UInt32Value{
-			Value: 50,
-		},
+		Name:   "test",
+		Weight: wrapperspb.UInt32(50),
 		RequestHeadersToAdd: []*core.HeaderValueOption{{
 			Header: &core.HeaderValue{
 				Key:   "foo",
 				Value: "bar",
 			},
-			Append: &wrappers.BoolValue{
-				Value: false,
-			},
+			Append: wrapperspb.Bool(false),
 		}},
 	}
 

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -27,8 +27,8 @@ import (
 	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	cachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -209,8 +209,8 @@ func generateListenersAndRouteConfigs(
 	// That causes some "no_cluster" errors in Envoy and the "TestUpdate"
 	// in the Knative serving test suite fails sometimes.
 	// Ref: https://github.com/knative/serving/blob/f6da03e5dfed78593c4f239c3c7d67c5d7c55267/test/conformance/ingress/update_test.go#L37
-	externalRouteConfig.ValidateClusters = &wrappers.BoolValue{Value: true}
-	internalRouteConfig.ValidateClusters = &wrappers.BoolValue{Value: true}
+	externalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
+	internalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
 
 	// Now we setup connection managers, that reference the routeconfigs via RDS.
 	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name)

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -22,8 +22,7 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	extAuthService "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/types/known/anypb"
 	"knative.dev/net-kourier/pkg/config"
 	envoy "knative.dev/net-kourier/pkg/envoy/api"
 )
@@ -38,13 +37,13 @@ func statusVHost() *route.VirtualHost {
 	)
 
 	// Make sure that ExtAuthz configuration is ignored on this path.
-	filter, _ := ptypes.MarshalAny(&extAuthService.ExtAuthzPerRoute{
+	filter, _ := anypb.New(&extAuthService.ExtAuthzPerRoute{
 		Override: &extAuthService.ExtAuthzPerRoute_Disabled{
 			Disabled: true,
 		},
 	})
 
-	vhost.TypedPerFilterConfig = map[string]*any.Any{
+	vhost.TypedPerFilterConfig = map[string]*anypb.Any{
 		wellknown.HTTPExternalAuthorization: filter,
 	}
 

--- a/test/config/extauthz/src/main.go
+++ b/test/config/extauthz/src/main.go
@@ -25,10 +25,10 @@ import (
 	"net"
 
 	authZ "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
-	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type Auth struct{}
@@ -48,7 +48,7 @@ func (ea Auth) Check(ctx context.Context, ar *authZ.CheckRequest) (*authZ.CheckR
 		Status: &status.Status{
 			Code:    int32(code.Code_PERMISSION_DENIED),
 			Message: "failed",
-			Details: []*any.Any{},
+			Details: []*anypb.Any{},
 		},
 	}, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -134,7 +134,6 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.4.3
-## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto


### PR DESCRIPTION
I love me a good cleanup and github.com/golang/protobuf says

> It has been superseded by the google.golang.org/protobuf module, which contains an updated and simplified API, support for protobuf reflection, and many other improvements. We recommend that new code use the google.golang.org/protobuf module.

So, why not? It feels cleaner too and the wrapper helpers are nice :).