### PR TITLE
Globally reconcile conflicted Ingresses on deletion

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -31,6 +31,8 @@ import (
 	"knative.dev/pkg/reconciler"
 )
 
+const conflictReason = "DomainConflict"
+
 type Reconciler struct {
 	xdsServer         *envoy.XdsServer
 	caches            *generator.Caches
@@ -52,7 +54,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		// If we had an error due to a duplicated domain, we must mark the ingress as failed with a
 		// custom status. We don't want to return an error in this case as we want to update its status.
 		logging.FromContext(ctx).Info(err.Error())
-		ing.Status.MarkLoadBalancerFailed("DomainConflict", "Ingress rejected: "+err.Error())
+		ing.Status.MarkLoadBalancerFailed(conflictReason, "Ingress rejected: "+err.Error())
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to update ingress: %w", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Tested in https://github.com/knative/serving/pull/11091

If an Ingress goes into a conflicting state it might never come back from that because nothing triggers its reconcilation again. Most notably: The deletion of the Ingress that caused the conflict should trigger reconcilation.

So this adds a global reconcilation of all Ingresses that are in a conflict state when any Ingress is removed.

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fixed a bug where an Ingress that is in a conflict never resumes from that state without kicking it.
```
