### PR TITLE
Drop --strict flag on ko

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,7 +47,7 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative net-kourier - ${config}"
-    ko resolve --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release


### PR DESCRIPTION
As per title. Since https://github.com/google/ko/commit/6586a72f8a458b6b2139fd8b97d4412afab91f03 this has been the default and we recently updated `ko` in CI.

/assign @nak3 @jmprusi @davidor 