### PR TITLE
Make access logging configurable in the types

### DIFF
--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -29,8 +29,13 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestNewHTTPConnectionManager(t *testing.T) {
-	connManager := NewHTTPConnectionManager("test")
+func TestNewHTTPConnectionManagerWithoutAccessLog(t *testing.T) {
+	connManager := NewHTTPConnectionManager("test", false /*enableAccessLog*/)
+	assert.Check(t, len(connManager.AccessLog) == 0)
+}
+
+func TestNewHTTPConnectionManagerWithAccessLog(t *testing.T) {
+	connManager := NewHTTPConnectionManager("test", true /*enableAccessLog*/)
 	accessLog := connManager.AccessLog[0]
 	accessLogPathAny := accessLog.ConfigType.(*envoy_config_filter_accesslog_v2.AccessLog_TypedConfig).TypedConfig
 	fileAccesLog := &accesslog_v2.FileAccessLog{}

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestNewHTTPListener(t *testing.T) {
-	manager := NewHTTPConnectionManager("test")
+	manager := NewHTTPConnectionManager("test", true /*enableAccessLog*/)
 
 	l, err := NewHTTPListener(manager, 8080)
 	assert.NilError(t, err)
@@ -45,7 +45,7 @@ func TestNewHTTPListener(t *testing.T) {
 }
 
 func TestNewHTTPSListener(t *testing.T) {
-	manager := NewHTTPConnectionManager("test")
+	manager := NewHTTPConnectionManager("test", true /*enableAccessLog*/)
 
 	certChain := []byte("some_certificate_chain")
 	privateKey := []byte("some_private_key")
@@ -76,7 +76,7 @@ func TestNewHTTPSListenerWithSNI(t *testing.T) {
 		PrivateKey:       []byte("key2"),
 	}}
 
-	manager := NewHTTPConnectionManager("test")
+	manager := NewHTTPConnectionManager("test", true /*enableAccessLog*/)
 	listener, err := NewHTTPSListenerWithSNI(manager, 8443, sniMatches)
 	assert.NilError(t, err)
 

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -213,8 +213,8 @@ func generateListenersAndRouteConfigs(
 	internalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
 
 	// Now we setup connection managers, that reference the routeconfigs via RDS.
-	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name)
-	internalManager := envoy.NewHTTPConnectionManager(internalRouteConfig.Name)
+	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name, true /*enableAccessLog*/)
+	internalManager := envoy.NewHTTPConnectionManager(internalRouteConfig.Name, true /*enableAccessLog*/)
 	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Ref #518 

Coming from the Golang types, this threads the possibility to configure access logging in the types. This will eventually connect with the ConfigMap to close the circle.

/assign @nak3 