### PR TITLE
Wait for rollout of new controllers after updating env

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -56,6 +56,7 @@ echo ">> Setup ExtAuthz"
 ko apply -f test/config/extauthz
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/externalauthz
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST=externalauthz.knative-serving:6000
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \


### PR DESCRIPTION
The test changes the environmenrt variables of the controller deployment but then doesn't wait until the new values are rolled out. This got made worse by us adding a readiness probe which prolongs the rollout.

This should make things consistent again.