### PR TITLE
Do not add target endpoints twice for probe

### DIFF
--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -81,7 +81,6 @@ func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, gatewayIp
 				target.PodPort = strconv.Itoa(int(config.HTTPPortExternal))
 				target.URLs = domainsToURL(domains, scheme)
 			}
-			targets = append(targets, target)
 		} else {
 			target = status.ProbeTarget{
 				PodIPs:  ips,


### PR DESCRIPTION
This patch removes stops adding target endpoints twice.

Currently the target endpoint for probe is added twice as:

https://github.com/knative-sandbox/net-kourier/blob/d3a2c5b5a60e32baea0b6c92c6e78430fe24e0c2/pkg/reconciler/ingress/lister.go#L84

https://github.com/knative-sandbox/net-kourier/blob/d3a2c5b5a60e32baea0b6c92c6e78430fe24e0c2/pkg/reconciler/ingress/lister.go#L93

It should be enough to add only once.
