### PR TITLE
Improve upgrade test script

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -66,6 +66,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/net-kourier
+        # Fetch all tags to determine the latest release version.
+        fetch-depth: 0
 
     - name: Install KinD
       run: |

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -82,7 +82,7 @@ function add_trap() {
 function wait_for_leader_controller() {
   echo -n "Waiting for leader Controller"
   for i in {1..150}; do # timeout after 5 minutes
-    local leader=$(kubectl get lease -n "${KOURIER_CONTROL_NAMESPACE}" -ojsonpath='{.items[*].spec.holderIdentity}' | cut -d"_" -f1 | grep "^3scale-kourier-control-" | head -1)
+    local leader=$(kubectl get lease -n "${KOURIER_CONTROL_NAMESPACE}" -ojsonpath='{.items[*].spec.holderIdentity}' | cut -d"_" -f1 | grep "^net-kourier-controller-" | head -1)
     # Make sure the leader pod exists.
     if [ -n "${leader}" ] && kubectl get pod "${leader}" -n "${KOURIER_CONTROL_NAMESPACE}" >/dev/null 2>&1; then
       echo -e "\nNew leader Controller has been elected"

--- a/test/e2e-upgrade-kind.sh
+++ b/test/e2e-upgrade-kind.sh
@@ -42,7 +42,7 @@ kubectl apply -f "https://github.com/knative-sandbox/net-kourier/releases/downlo
   kubectl apply -f -
 
 echo "Wait for all deployments to be up"
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/3scale-kourier-control
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/net-kourier-controller
 kubectl -n "${KOURIER_GATEWAY_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/3scale-kourier-gateway
 
 # Remove the following files in case we failed to clean them up in an earlier test.


### PR DESCRIPTION
This patch improves `e2e-upgrade-kind.sh` by:

- Use `NodePort` for the gateway service as the script is called by github action.
- Use the latest release version instead of fixed `v0.23.0`.