### PR TITLE
Support `httpProtocol: Redirected`

### DIFF
--- a/pkg/envoy/api/route.go
+++ b/pkg/envoy/api/route.go
@@ -66,3 +66,25 @@ func NewRoute(name string,
 		RequestHeadersToAdd: headersToAdd(headers),
 	}
 }
+
+func NewRedirectRoute(name string,
+	headersMatch []*route.HeaderMatcher,
+	path string,
+) *route.Route {
+	return &route.Route{
+		Name: name,
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Prefix{
+				Prefix: path,
+			},
+			Headers: headersMatch,
+		},
+		Action: &route.Route_Redirect{
+			Redirect: &route.RedirectAction{
+				SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
+					HttpsRedirect: true,
+				},
+			},
+		},
+	}
+}

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -175,10 +175,16 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 			}
 
 			if len(wrs) != 0 {
-				routes = append(routes, envoy.NewRoute(
-					pathName, matchHeadersFromHTTPPath(httpPath), path, wrs, 0, httpPath.AppendHeaders, httpPath.RewriteHost))
+				if ingress.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected && rule.Visibility == v1alpha1.IngressVisibilityExternalIP {
+					routes = append(routes, envoy.NewRedirectRoute(
+						pathName, matchHeadersFromHTTPPath(httpPath), path))
+				} else {
+					routes = append(routes, envoy.NewRoute(
+						pathName, matchHeadersFromHTTPPath(httpPath), path, wrs, 0, httpPath.AppendHeaders, httpPath.RewriteHost))
+				}
 				if len(ingress.Spec.TLS) != 0 {
-					tlsRoutes = append(tlsRoutes, routes...)
+					tlsRoutes = append(tlsRoutes, envoy.NewRoute(
+						pathName, matchHeadersFromHTTPPath(httpPath), path, wrs, 0, httpPath.AppendHeaders, httpPath.RewriteHost))
 				}
 			}
 		}

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -35,7 +35,6 @@ export "GATEWAY_NAMESPACE_OVERRIDE=${KOURIER_GATEWAY_NAMESPACE}"
 echo ">> Running conformance tests"
 go test -count=1 -short -timeout=20m -tags=e2e ./test/conformance/... ./test/e2e/... \
   --enable-alpha --enable-beta \
-  --skip-tests="httpoption" \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,7 +25,6 @@ go_test_e2e -timeout=20m -parallel=12 \
   ./test/conformance \
   ./test/e2e/ \
   --enable-alpha --enable-beta \
-  --skip-tests="httpoption" \
   --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Give the controller time to sync with the rest of the system components.


### PR DESCRIPTION
This patch supports `Spec.HTTPOption` in KIngress as well as
`httpProtocol: Redirected` in config-network.

Note about internal stuff as the redirect support needs some
internal changes:

Currently RouteConfig (`external_services`) is used by both HTTP
Listener and HTTPS Listener when TLS is enabled.
However, to add redirect support, we cannot share the RouteConfig as
HTTPListener needs Route with `RedirectAction`.

So, this patch introduces another RouteConfig
(`external_tls_services`) for the HTTPS Listener.

Fix https://github.com/knative/networking/issues/304 https://github.com/knative-sandbox/net-kourier/issues/428

**Release Note*

```release-note
net-kourier supports `httpProtocol: Redirected` in config-network.
```
