### PR TITLE
Bump default envoy version to 1.17

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -45,7 +45,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.16-latest
+          image: docker.io/envoyproxy/envoy:v1.17-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This should fix the flaky `TestActivatorHAGraceful` test as 1.17 fixed a bug in Envoy that'd cause intermittent failures due to the endpoint updates caused by that test. See https://github.com/envoyproxy/envoy/pull/13906.

**Note:** I ran the tests 10 times locally, all passing while based on 1.16 it failed 2x while just running the test 5 times.

/assign @nak3 