### PR TITLE
Split RouteConfig for HTTP and HTTPS listeners

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -39,12 +39,13 @@ import (
 )
 
 const (
-	envCertsSecretNamespace = "CERTS_SECRET_NAMESPACE"
-	envCertsSecretName      = "CERTS_SECRET_NAME"
-	certFieldInSecret       = "tls.crt"
-	keyFieldInSecret        = "tls.key"
-	externalRouteConfigName = "external_services"
-	internalRouteConfigName = "internal_services"
+	envCertsSecretNamespace    = "CERTS_SECRET_NAMESPACE"
+	envCertsSecretName         = "CERTS_SECRET_NAME"
+	certFieldInSecret          = "tls.crt"
+	keyFieldInSecret           = "tls.key"
+	externalRouteConfigName    = "external_services"
+	externalTLSRouteConfigName = "external_tls_services"
+	internalRouteConfigName    = "internal_services"
 )
 
 // ErrDomainConflict is an error produces when two ingresses have conflicting domains.
@@ -130,11 +131,13 @@ func (caches *Caches) ToEnvoySnapshot(ctx context.Context) (cache.Snapshot, erro
 
 	localVHosts := make([]*route.VirtualHost, 0, len(caches.translatedIngresses)+1)
 	externalVHosts := make([]*route.VirtualHost, 0, len(caches.translatedIngresses))
+	externalTLSVHosts := make([]*route.VirtualHost, 0, len(caches.translatedIngresses))
 	snis := sniMatches{}
 
 	for _, translatedIngress := range caches.translatedIngresses {
 		localVHosts = append(localVHosts, translatedIngress.internalVirtualHosts...)
 		externalVHosts = append(externalVHosts, translatedIngress.externalVirtualHosts...)
+		externalTLSVHosts = append(externalTLSVHosts, translatedIngress.externalTLSVirtualHosts...)
 
 		for _, match := range translatedIngress.sniMatches {
 			snis.consume(match)
@@ -146,6 +149,7 @@ func (caches *Caches) ToEnvoySnapshot(ctx context.Context) (cache.Snapshot, erro
 	listeners, routes, err := generateListenersAndRouteConfigs(
 		ctx,
 		externalVHosts,
+		externalTLSVHosts,
 		localVHosts,
 		snis.list(),
 		caches.kubeClient,
@@ -200,6 +204,7 @@ func (caches *Caches) deleteTranslatedIngress(ingressName, ingressNamespace stri
 func generateListenersAndRouteConfigs(
 	ctx context.Context,
 	externalVirtualHosts []*route.VirtualHost,
+	externalTLSVirtualHosts []*route.VirtualHost,
 	clusterLocalVirtualHosts []*route.VirtualHost,
 	sniMatches []*envoy.SNIMatch,
 	kubeclient kubeclient.Interface) ([]cachetypes.Resource, []cachetypes.Resource, error) {
@@ -211,6 +216,7 @@ func generateListenersAndRouteConfigs(
 
 	// First, we save the RouteConfigs with the proper name and all the virtualhosts etc. into the cache.
 	externalRouteConfig := envoy.NewRouteConfig(externalRouteConfigName, externalVirtualHosts)
+	externalTLSRouteConfig := envoy.NewRouteConfig(externalTLSRouteConfigName, externalTLSVirtualHosts)
 	internalRouteConfig := envoy.NewRouteConfig(internalRouteConfigName, clusterLocalVirtualHosts)
 
 	// Without this we can generate routes that point to non-existing clusters
@@ -218,10 +224,12 @@ func generateListenersAndRouteConfigs(
 	// in the Knative serving test suite fails sometimes.
 	// Ref: https://github.com/knative/serving/blob/f6da03e5dfed78593c4f239c3c7d67c5d7c55267/test/conformance/ingress/update_test.go#L37
 	externalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
+	externalTLSRouteConfig.ValidateClusters = wrapperspb.Bool(true)
 	internalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
 
 	// Now we setup connection managers, that reference the routeconfigs via RDS.
 	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name, cfg.Kourier.EnableServiceAccessLogging)
+	externalTLSManager := envoy.NewHTTPConnectionManager(externalTLSRouteConfig.Name, cfg.Kourier.EnableServiceAccessLogging)
 	internalManager := envoy.NewHTTPConnectionManager(internalRouteConfig.Name, cfg.Kourier.EnableServiceAccessLogging)
 	externalHTTPEnvoyListener, err := envoy.NewHTTPListener(externalManager, config.HTTPPortExternal)
 	if err != nil {
@@ -238,14 +246,14 @@ func generateListenersAndRouteConfigs(
 	// TLS field, that takes precedence. If there is not, TLS will be configured
 	// using a single cert for all the services if the creds are given via ENV.
 	if len(sniMatches) > 0 {
-		externalHTTPSEnvoyListener, err := envoy.NewHTTPSListenerWithSNI(externalManager, config.HTTPSPortExternal, sniMatches)
+		externalHTTPSEnvoyListener, err := envoy.NewHTTPSListenerWithSNI(externalTLSManager, config.HTTPSPortExternal, sniMatches)
 		if err != nil {
 			return nil, nil, err
 		}
 		listeners = append(listeners, externalHTTPSEnvoyListener)
 	} else if useHTTPSListenerWithOneCert() {
 		externalHTTPSEnvoyListener, err := newExternalEnvoyListenerWithOneCert(
-			ctx, externalManager, kubeclient,
+			ctx, externalTLSManager, kubeclient,
 		)
 		if err != nil {
 			return nil, nil, err
@@ -253,6 +261,9 @@ func generateListenersAndRouteConfigs(
 		listeners = append(listeners, externalHTTPSEnvoyListener)
 	}
 
+	if len(sniMatches) > 0 || useHTTPSListenerWithOneCert() {
+		return listeners, []cachetypes.Resource{externalRouteConfig, externalTLSRouteConfig, internalRouteConfig}, nil
+	}
 	return listeners, []cachetypes.Resource{externalRouteConfig, internalRouteConfig}, nil
 }
 

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -241,6 +241,7 @@ func generateListenersAndRouteConfigs(
 	}
 
 	listeners := []cachetypes.Resource{externalHTTPEnvoyListener, internalEnvoyListener}
+	routes := []cachetypes.Resource{externalRouteConfig, internalRouteConfig}
 
 	// Configure TLS Listener. If there's at least one ingress that contains the
 	// TLS field, that takes precedence. If there is not, TLS will be configured
@@ -251,6 +252,7 @@ func generateListenersAndRouteConfigs(
 			return nil, nil, err
 		}
 		listeners = append(listeners, externalHTTPSEnvoyListener)
+		routes = append(routes, externalTLSRouteConfig)
 	} else if useHTTPSListenerWithOneCert() {
 		externalHTTPSEnvoyListener, err := newExternalEnvoyListenerWithOneCert(
 			ctx, externalTLSManager, kubeclient,
@@ -259,12 +261,10 @@ func generateListenersAndRouteConfigs(
 			return nil, nil, err
 		}
 		listeners = append(listeners, externalHTTPSEnvoyListener)
+		routes = append(routes, externalTLSRouteConfig)
 	}
 
-	if len(sniMatches) > 0 || useHTTPSListenerWithOneCert() {
-		return listeners, []cachetypes.Resource{externalRouteConfig, externalTLSRouteConfig, internalRouteConfig}, nil
-	}
-	return listeners, []cachetypes.Resource{externalRouteConfig, internalRouteConfig}, nil
+	return listeners, routes, nil
 }
 
 // Returns true if we need to modify the HTTPS listener with just one cert

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -206,7 +206,6 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 		}
 
 		internalHosts = append(internalHosts, virtualHost)
-
 		if rule.Visibility == v1alpha1.IngressVisibilityExternalIP {
 			externalHosts = append(externalHosts, virtualHost)
 			if virtualTLSHost != nil {

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -89,8 +89,9 @@ func TestIngressTranslator(t *testing.T) {
 						v3.Cluster_STATIC,
 					),
 				},
-				externalVirtualHosts: vHosts,
-				internalVirtualHosts: vHosts,
+				externalVirtualHosts:    vHosts,
+				externalTLSVirtualHosts: vHosts,
+				internalVirtualHosts:    vHosts,
 			}
 		}(),
 	}, {
@@ -154,8 +155,9 @@ func TestIngressTranslator(t *testing.T) {
 						v3.Cluster_STATIC,
 					),
 				},
-				externalVirtualHosts: vHosts,
-				internalVirtualHosts: vHosts,
+				externalVirtualHosts:    vHosts,
+				externalTLSVirtualHosts: vHosts,
+				internalVirtualHosts:    vHosts,
 			}
 		}(),
 	}, {
@@ -244,8 +246,9 @@ func TestIngressTranslator(t *testing.T) {
 						v3.Cluster_LOGICAL_DNS,
 					),
 				},
-				externalVirtualHosts: vHosts,
-				internalVirtualHosts: vHosts,
+				externalVirtualHosts:    vHosts,
+				externalTLSVirtualHosts: vHosts,
+				internalVirtualHosts:    vHosts,
 			}
 		}(),
 	}, {
@@ -296,8 +299,9 @@ func TestIngressTranslator(t *testing.T) {
 						v3.Cluster_STATIC,
 					),
 				},
-				externalVirtualHosts: vHosts,
-				internalVirtualHosts: vHosts,
+				externalVirtualHosts:    vHosts,
+				externalTLSVirtualHosts: vHosts,
+				internalVirtualHosts:    vHosts,
 			}
 		}(),
 	}, {
@@ -348,8 +352,9 @@ func TestIngressTranslator(t *testing.T) {
 						v3.Cluster_LOGICAL_DNS,
 					),
 				},
-				externalVirtualHosts: vHosts,
-				internalVirtualHosts: vHosts,
+				externalVirtualHosts:    vHosts,
+				externalTLSVirtualHosts: vHosts,
+				internalVirtualHosts:    vHosts,
 			}
 		}(),
 	}, {

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -90,7 +90,7 @@ func TestIngressTranslator(t *testing.T) {
 					),
 				},
 				externalVirtualHosts:    vHosts,
-				externalTLSVirtualHosts: vHosts,
+				externalTLSVirtualHosts: []*route.VirtualHost{},
 				internalVirtualHosts:    vHosts,
 			}
 		}(),
@@ -247,7 +247,7 @@ func TestIngressTranslator(t *testing.T) {
 					),
 				},
 				externalVirtualHosts:    vHosts,
-				externalTLSVirtualHosts: vHosts,
+				externalTLSVirtualHosts: []*route.VirtualHost{},
 				internalVirtualHosts:    vHosts,
 			}
 		}(),
@@ -300,7 +300,7 @@ func TestIngressTranslator(t *testing.T) {
 					),
 				},
 				externalVirtualHosts:    vHosts,
-				externalTLSVirtualHosts: vHosts,
+				externalTLSVirtualHosts: []*route.VirtualHost{},
 				internalVirtualHosts:    vHosts,
 			}
 		}(),
@@ -353,7 +353,7 @@ func TestIngressTranslator(t *testing.T) {
 					),
 				},
 				externalVirtualHosts:    vHosts,
-				externalTLSVirtualHosts: vHosts,
+				externalTLSVirtualHosts: []*route.VirtualHost{},
 				internalVirtualHosts:    vHosts,
 			}
 		}(),


### PR DESCRIPTION
Currently RouteConfig (`external_services`) is used by both HTTP
Listener and HTTPS Listener when TLS is enabled.
However, to add redirect support, we cannot share the RouteConfig as
HTTPListener needs Route with `RedirectAction`.

So, this patch introduces another RouteConfig
(`external_tls_services`) for the HTTPS Listener.

Part of https://github.com/knative-sandbox/net-kourier/pull/619