### PR TITLE
Set ValidateClusters in NewRouteConfig

### DIFF
--- a/pkg/envoy/api/http_connection_manager.go
+++ b/pkg/envoy/api/http_connection_manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"knative.dev/net-kourier/pkg/config"
 )
@@ -86,5 +87,10 @@ func NewRouteConfig(name string, virtualHosts []*route.VirtualHost) *route.Route
 	return &route.RouteConfiguration{
 		Name:         name,
 		VirtualHosts: virtualHosts,
+		// Without this validation we can generate routes that point to non-existing clusters
+		// That causes some "no_cluster" errors in Envoy and the "TestUpdate"
+		// in the Knative serving test suite fails sometimes.
+		// Ref: https://github.com/knative/serving/blob/f6da03e5dfed78593c4f239c3c7d67c5d7c55267/test/conformance/ingress/update_test.go#L37
+		ValidateClusters: wrapperspb.Bool(true),
 	}
 }

--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"gotest.tools/v3/assert"
 )
 
@@ -55,8 +56,9 @@ func TestNewRouteConfig(t *testing.T) {
 
 	got := NewRouteConfig("test", []*route.VirtualHost{vhost})
 	want := &route.RouteConfiguration{
-		Name:         "test",
-		VirtualHosts: []*route.VirtualHost{vhost},
+		Name:             "test",
+		VirtualHosts:     []*route.VirtualHost{vhost},
+		ValidateClusters: wrapperspb.Bool(true),
 	}
 
 	assert.DeepEqual(t, got, want, protocmp.Transform())

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -28,7 +28,6 @@ import (
 	cachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/google/uuid"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -218,14 +217,6 @@ func generateListenersAndRouteConfigs(
 	externalRouteConfig := envoy.NewRouteConfig(externalRouteConfigName, externalVirtualHosts)
 	externalTLSRouteConfig := envoy.NewRouteConfig(externalTLSRouteConfigName, externalTLSVirtualHosts)
 	internalRouteConfig := envoy.NewRouteConfig(internalRouteConfigName, clusterLocalVirtualHosts)
-
-	// Without this we can generate routes that point to non-existing clusters
-	// That causes some "no_cluster" errors in Envoy and the "TestUpdate"
-	// in the Knative serving test suite fails sometimes.
-	// Ref: https://github.com/knative/serving/blob/f6da03e5dfed78593c4f239c3c7d67c5d7c55267/test/conformance/ingress/update_test.go#L37
-	externalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
-	externalTLSRouteConfig.ValidateClusters = wrapperspb.Bool(true)
-	internalRouteConfig.ValidateClusters = wrapperspb.Bool(true)
 
 	// Now we setup connection managers, that reference the routeconfigs via RDS.
 	externalManager := envoy.NewHTTPConnectionManager(externalRouteConfig.Name, cfg.Kourier.EnableServiceAccessLogging)


### PR DESCRIPTION
Current code adds the validation one by one, but we always need it.
So this patch sets ValidateClusters in NewRouteConfig by default.

/kind cleanup
