### PR TITLE
WIP: Run conformance test in parallel

### DIFF
--- a/test/conformance/ingress_test.go
+++ b/test/conformance/ingress_test.go
@@ -20,11 +20,25 @@ limitations under the License.
 package conformance
 
 import (
+	"strconv"
 	"testing"
 
 	"knative.dev/networking/test/conformance/ingress"
 )
 
+const iterations = 12
+
 func TestIngressConformance(t *testing.T) {
-	ingress.RunConformance(t)
+	t.Parallel()
+	for i := 0; i < iterations; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			ingress.RunConformance(t)
+		})
+
+		// With `-short` only run a single iteration.
+		if testing.Short() {
+			break
+		}
+	}
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,7 +21,7 @@ initialize "$@" --skip-istio-addon
 
 failed=0
 
-go_test_e2e -timeout=20m -parallel=12 \
+go_test_e2e -timeout=40m -parallel=12 \
   ./test/conformance \
   ./test/e2e/ \
   --enable-alpha --enable-beta \


### PR DESCRIPTION
This patch is a same reason with https://github.com/knative-sandbox/net-istio/commit/8e369384fc8338b211061bab004f3ccd3faec0af

This will bring the load closer to the level of concurrency we see in
Serving e2e tests.