### PR TITLE
use latest version of knative serving and kourier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Kourier is passing the knative serving e2e and conformance tests:
 - Install Knative Serving, ideally without Istio:
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/v0.17.0/serving-crds.yaml
-kubectl apply -f https://github.com/knative/serving/releases/download/v0.17.0/serving-core.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/v0.26.0/serving-crds.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/v0.26.0/serving-core.yaml
 ```
 
 - Then install Kourier:
 
 ```bash
-kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.17.0/kourier.yaml
+kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.26.0/kourier.yaml
 ```
 
 - Configure Knative Serving to use the proper "ingress.class":


### PR DESCRIPTION
Update README to latest versions of serving and kourier



# Changes

:broom: Update or clean up current behavior


/kind documentation




<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**


:page_facing_up:  README updated to latest version of knative serving and kourier



