### PR TITLE
Hardcode upgrade test version as detection doesn't work in actions

### DIFF
--- a/test/e2e-upgrade-kind.sh
+++ b/test/e2e-upgrade-kind.sh
@@ -23,7 +23,7 @@ source $(dirname $0)/e2e-common.sh
 KOURIER_GATEWAY_NAMESPACE=kourier-system
 KOURIER_CONTROL_NAMESPACE=knative-serving
 TEST_NAMESPACE=serving-tests
-LATEST_RELEASE_VERSION=$(latest_version)
+LATEST_RELEASE_VERSION="knative-v1.0.0"
 
 $(dirname $0)/upload-test-images.sh
 


### PR DESCRIPTION
`latest_version` doesn't currently work in Github Actions (on PRs at least), so this hardcodes things so the upgrade tests actually run for now. We should fix this tho.

/assign @nak3 