### PR TITLE
Adds k8s recommended labels

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -18,7 +18,7 @@ metadata:
   name: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -18,6 +18,7 @@ metadata:
   name: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -18,4 +18,6 @@ metadata:
   name: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 data:
   envoy-bootstrap.yaml: |

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 data:
   envoy-bootstrap.yaml: |

--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 data:
   _example: |

--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 data:
   _example: |

--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -30,6 +30,7 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -59,6 +60,7 @@ metadata:
   name: net-kourier
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,9 +31,9 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -61,9 +61,9 @@ metadata:
   name: net-kourier
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -28,6 +30,8 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -55,6 +59,8 @@ metadata:
   name: net-kourier
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   replicas: 1
@@ -70,6 +72,8 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   ports:

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -72,6 +73,7 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 spec:
   replicas: 1
@@ -73,9 +73,9 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 spec:
   ports:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 spec:
   strategy:
@@ -97,9 +97,9 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 spec:
   ports:
@@ -122,9 +122,9 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
-    app.kubernetes.io/name: kourier
+    app.kubernetes.io/component: net-kourier
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     serving.knative.dev/release: devel
 spec:
   ports:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -96,6 +97,7 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -120,6 +122,7 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/name: kourier
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   strategy:
@@ -94,6 +96,8 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   ports:
@@ -116,6 +120,8 @@ metadata:
   namespace: kourier-system
   labels:
     networking.knative.dev/ingress-provider: kourier
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   ports:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,8 +35,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|")
+    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -24,6 +24,7 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/name: chaosduck
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -35,6 +36,7 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/name: chaosduck
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -53,6 +55,7 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/name: chaosduck
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
@@ -72,6 +75,7 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/name: chaosduck
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -24,9 +24,6 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 
 ---
@@ -36,9 +33,6 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -55,9 +49,6 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -75,9 +66,6 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   selector:

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -24,6 +24,8 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 
 ---
@@ -33,6 +35,8 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -49,6 +53,8 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -66,6 +72,8 @@ metadata:
   name: chaosduck
   namespace: kourier-system
   labels:
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: knative-serving
     serving.knative.dev/release: devel
 spec:
   selector:


### PR DESCRIPTION
# Changes

Adds Kubernetes recommended labels to networking as discussed in https://github.com/knative/networking/issues/552

Note that changes to the labels in `vendor/knative.dev/networking` should be handled by the automation once https://github.com/knative/networking/pull/555 merges. 

/kind enhancement

/assign @dprotaso 