### PR TITLE
Revert "Hardcode upgrade test version as detection doesn't work in actions (#687)

### DIFF
--- a/test/e2e-upgrade-kind.sh
+++ b/test/e2e-upgrade-kind.sh
@@ -23,7 +23,7 @@ source $(dirname $0)/e2e-common.sh
 KOURIER_GATEWAY_NAMESPACE=kourier-system
 KOURIER_CONTROL_NAMESPACE=knative-serving
 TEST_NAMESPACE=serving-tests
-LATEST_RELEASE_VERSION="knative-v1.0.0"
+LATEST_RELEASE_VERSION=$(latest_version)
 
 $(dirname $0)/upload-test-images.sh
 


### PR DESCRIPTION
This reverts commit f9852b4c5e6128354bedfd10b0faf96ad8d00629.

The `latest_version` function has been fixed meanwhile.

/assign @nak3 