### PR TITLE
Introduce `KOURIER_HTTPOPTION_DISABLED` env variable to disable redirect

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -19,6 +19,7 @@ package generator
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -175,7 +176,9 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 			}
 
 			if len(wrs) != 0 {
-				if ingress.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected && rule.Visibility == v1alpha1.IngressVisibilityExternalIP {
+				// Do not create redirect route when KOURIER_HTTPOPTION_DISABLED is set. This option is useful when front end proxy handles the redirection.
+				// e.g. Kourier on OpenShift handles HTTPOption by OpenShift Route so KOURIER_HTTPOPTION_DISABLED should be set.
+				if _, ok := os.LookupEnv("KOURIER_HTTPOPTION_DISABLED"); !ok && ingress.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected && rule.Visibility == v1alpha1.IngressVisibilityExternalIP {
 					routes = append(routes, envoy.NewRedirectRoute(
 						pathName, matchHeadersFromHTTPPath(httpPath), path))
 				} else {

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package generator
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -693,7 +692,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			os.Setenv("KOURIER_HTTPOPTION_DISABLED", "true")
+			t.Setenv("KOURIER_HTTPOPTION_DISABLED", "true")
 			ctx, _ := pkgtest.SetupFakeContext(t)
 			kubeclient := fake.NewSimpleClientset(test.state...)
 
@@ -716,7 +715,6 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 				cmp.AllowUnexported(translatedIngress{}),
 				protocmp.Transform(),
 			)
-			os.Unsetenv("KOURIER_HTTPOPTION_DISABLED")
 		})
 	}
 }

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -107,7 +107,7 @@ func TestIngressTranslator(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretns", "secretname"),
+			secret("secretname"),
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -174,7 +174,7 @@ func TestIngressTranslator(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretns", "secretname"),
+			secret("secretname"),
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -259,7 +259,7 @@ func TestIngressTranslator(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretns", "secretname"),
+			secret("secretname"),
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -822,10 +822,10 @@ var lbEndpoints = []*endpoint.LbEndpoint{
 	envoy.NewLBEndpoint("5.5.5.5", 8080),
 }
 
-func secret(ns, name string) *corev1.Secret {
+func secret(name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
+			Namespace: "secretns",
 			Name:      name,
 		},
 		Data: map[string][]byte{

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -107,7 +107,7 @@ func TestIngressTranslator(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretname"),
+			secret,
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -174,7 +174,7 @@ func TestIngressTranslator(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretname"),
+			secret,
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -259,7 +259,7 @@ func TestIngressTranslator(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretname"),
+			secret,
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -567,7 +567,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretns", "secretname"),
+			secret,
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -635,7 +635,7 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 		state: []runtime.Object{
 			svc("servicens", "servicename"),
 			eps("servicens", "servicename"),
-			secret("secretns", "secretname"),
+			secret,
 		},
 		want: func() *translatedIngress {
 			vHosts := []*route.VirtualHost{
@@ -822,20 +822,17 @@ var lbEndpoints = []*endpoint.LbEndpoint{
 	envoy.NewLBEndpoint("5.5.5.5", 8080),
 }
 
-func secret(name string) *corev1.Secret {
-	return &corev1.Secret{
+var (
+	cert       = []byte("cert")
+	privateKey = []byte("key")
+	secret     = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "secretns",
-			Name:      name,
+			Name:      "secretname",
 		},
 		Data: map[string][]byte{
 			"tls.crt": cert,
 			"tls.key": privateKey,
 		},
 	}
-}
-
-var (
-	cert       = []byte("cert")
-	privateKey = []byte("key")
 )


### PR DESCRIPTION
This patch introduces `KOURIER_HTTPOPTION_DISABLED` env variable to stop creating redirect route when it is set.
This option is useful when front end proxy handles the redirection by `spec.HTTPOption`.
e.g. Kourier on OpenShift handles `HTTPOption` by OpenShift Route so `KOURIER_HTTPOPTION_DISABLED` should be set.