### PR TITLE
Bump Kourier Gateway (envoy) image version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -26,8 +26,8 @@ jobs:
 
         gateway:
         - quay.io/maistra/proxyv2-ubi8:2.1.0
-        - docker.io/envoyproxy/envoy:v1.17-latest
         - docker.io/envoyproxy/envoy:v1.18-latest
+        - docker.io/envoyproxy/envoy:v1.19-latest
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -48,7 +48,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.17-latest
+          image: docker.io/envoyproxy/envoy:v1.18-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
Envoy 1.17 is EOL on 2022/01/11[1], so this patch bumps envoy image version to 1.18.
Also it starts testing 1.19 and 1.18.

[1] https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#release-schedule

```release-note
Kourier Gateway bundles Envoy 1.18 image.
```