### PR TITLE
Fix TLS listener filter chains when configured with both a secret (via env vars) and SNI

### DIFF
--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -45,7 +45,7 @@ func NewHTTPListener(manager *hcm.HttpConnectionManager, port uint32) (*listener
 	}
 
 	return &listener.Listener{
-		Name:    fmt.Sprintf("listener_%d", port),
+		Name:    CreateListenerName(port),
 		Address: createAddress(port),
 		FilterChains: []*listener.FilterChain{{
 			Filters: filters,
@@ -73,7 +73,7 @@ func NewHTTPSListener(
 	}
 
 	return &listener.Listener{
-		Name:    fmt.Sprintf("listener_%d", port),
+		Name:    CreateListenerName(port),
 		Address: createAddress(port),
 		FilterChains: []*listener.FilterChain{{
 			Filters: filters,
@@ -96,7 +96,7 @@ func NewHTTPSListenerWithSNI(manager *hcm.HttpConnectionManager, port uint32, sn
 	}
 
 	return &listener.Listener{
-		Name:         fmt.Sprintf("listener_%d", port),
+		Name:         CreateListenerName(port),
 		Address:      createAddress(port),
 		FilterChains: filterChains,
 		ListenerFilters: []*listener.ListenerFilter{{
@@ -106,6 +106,11 @@ func NewHTTPSListenerWithSNI(manager *hcm.HttpConnectionManager, port uint32, sn
 			Name: wellknown.TlsInspector,
 		}},
 	}, nil
+}
+
+// CreateListenerName returns a listener name based on port
+func CreateListenerName(port uint32) string {
+	return fmt.Sprintf("listener_%d", port)
 }
 
 func createAddress(port uint32) *core.Address {

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -49,7 +49,10 @@ func TestNewHTTPSListener(t *testing.T) {
 	certChain := []byte("some_certificate_chain")
 	privateKey := []byte("some_private_key")
 
-	l, err := NewHTTPSListener(manager, 8081, certChain, privateKey)
+	filterChain, err := CreateFilterChainFromCertificateAndPrivateKey(manager, certChain, privateKey)
+	assert.NilError(t, err)
+
+	l, err := NewHTTPSListener(8081, filterChain)
 	assert.NilError(t, err)
 
 	assert.Equal(t, core.SocketAddress_TCP, l.Address.GetSocketAddress().Protocol)

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -245,15 +245,15 @@ func generateListenersAndRouteConfigs(
 
 		// if a certificate is configured, add a new filter chain to TLS listener
 		if useHTTPSListenerWithOneCert() {
-			externalHTTPSEnvoyListenerWithOneCert, err := newExternalEnvoyListenerWithOneCert(
+			externalHTTPSEnvoyListenerWithOneCertFilterChain, err := newExternalEnvoyListenerWithOneCertFilterChain(
 				ctx, externalTLSManager, kubeclient,
 			)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			externalHTTPSEnvoyListener.FilterChains = append(externalHTTPSEnvoyListenerWithOneCert.FilterChains,
-				externalHTTPSEnvoyListener.FilterChains...)
+			externalHTTPSEnvoyListener.FilterChains = append(externalHTTPSEnvoyListener.FilterChains,
+				externalHTTPSEnvoyListenerWithOneCertFilterChain)
 		}
 
 		listeners = append(listeners, externalHTTPSEnvoyListener)
@@ -288,7 +288,7 @@ func sslCreds(ctx context.Context, kubeClient kubeclient.Interface, secretNamesp
 	return secret.Data[certFieldInSecret], secret.Data[keyFieldInSecret], nil
 }
 
-func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnmanagerv3.HttpConnectionManager, kubeClient kubeclient.Interface) (*v3.Listener, error) {
+func newExternalEnvoyListenerWithOneCertFilterChain(ctx context.Context, manager *httpconnmanagerv3.HttpConnectionManager, kubeClient kubeclient.Interface) (*v3.FilterChain, error) {
 	certificateChain, privateKey, err := sslCreds(
 		ctx, kubeClient, os.Getenv(envCertsSecretNamespace), os.Getenv(envCertsSecretName),
 	)
@@ -296,5 +296,14 @@ func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnm
 		return nil, err
 	}
 
-	return envoy.NewHTTPSListener(manager, config.HTTPSPortExternal, certificateChain, privateKey)
+	return envoy.CreateFilterChainFromCertificateAndPrivateKey(manager, certificateChain, privateKey)
+}
+
+func newExternalEnvoyListenerWithOneCert(ctx context.Context, manager *httpconnmanagerv3.HttpConnectionManager, kubeClient kubeclient.Interface) (*v3.Listener, error) {
+	filterChain, err := newExternalEnvoyListenerWithOneCertFilterChain(ctx, manager, kubeClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return envoy.NewHTTPSListener(config.HTTPSPortExternal, filterChain)
 }

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -243,6 +243,7 @@ func generateListenersAndRouteConfigs(
 			return nil, nil, err
 		}
 
+		// if a certificate is configured, add a new filter chain to TLS listener
 		if useHTTPSListenerWithOneCert() {
 			externalHTTPSEnvoyListenerWithOneCert, err := newExternalEnvoyListenerWithOneCert(
 				ctx, externalTLSManager, kubeclient,

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -242,6 +242,19 @@ func generateListenersAndRouteConfigs(
 		if err != nil {
 			return nil, nil, err
 		}
+
+		if useHTTPSListenerWithOneCert() {
+			externalHTTPSEnvoyListenerWithOneCert, err := newExternalEnvoyListenerWithOneCert(
+				ctx, externalTLSManager, kubeclient,
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			externalHTTPSEnvoyListener.FilterChains = append(externalHTTPSEnvoyListenerWithOneCert.FilterChains,
+				externalHTTPSEnvoyListener.FilterChains...)
+		}
+
 		listeners = append(listeners, externalHTTPSEnvoyListener)
 		routes = append(routes, externalTLSRouteConfig)
 	} else if useHTTPSListenerWithOneCert() {


### PR DESCRIPTION
# Changes

When TLS is configured with 1 or more SNI, and if a certificate is set via environment variables (`CERTS_SECRET_NAMESPACE` and `CERTS_SECRET_NAME`), append a default filter chain to the TLS listener (applied if none of the SNI matches).

/kind bug

Fixes #740
Initial issue (with domain mapping) here: https://github.com/knative/serving/issues/12377#issuecomment-1005019057

**Release Note**

Not sure about this, but we can go for this (open to suggestions):

```release-note
Add a filter chain to the HTTPS listener with SNI, applied if no SNI matches
```