### PR TITLE
Ext auth service : remove `split_words` to honor `KOURIER_EXTAUTHZ*` env vars

### DIFF
--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -54,10 +54,10 @@ type ExternalAuthzConfig struct {
 }
 
 type config struct {
-	Host             string `split_words:"true"`
-	FailureModeAllow bool   `split_words:"true"`
-	MaxRequestBytes  uint32 `split_words:"true" default:"8192"`
-	Timeout          int    `split_words:"true" default:"2000"`
+	Host             string
+	FailureModeAllow bool
+	MaxRequestBytes  uint32 `default:"8192"`
+	Timeout          int    `default:"2000"`
 }
 
 func init() {


### PR DESCRIPTION
# Changes

:bug: Ext auth service : remove `split_words` to honor `KOURIER_EXTAUTHZ*` env vars

/kind bug

With this fix, `KOURIER_EXTAUTHZ_FAILUREMODEALLOW` and `KOURIER_EXTAUTHZ_MAXREQUESTBYTES` env vars are honored as the docs states. Before that, users should set `KOURIER_EXTAUTHZ_FAILURE_MODE_ALLOW` and `KOURIER_EXTAUTHZ_MAX_REQUEST_BYTES` (notice the separating `_`) to change those parameters (see [envconfig `split_words` documentation](https://github.com/kelseyhightower/envconfig/blob/v1.4.0/README.md#struct-tag-support)).

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

No impacts on clients if they were following the [config of ext auth in the `README.md`](https://github.com/knative-sandbox/net-kourier/blob/a95fd30/README.md#external-authorization-configuration).

**Docs**

No docs.