### PR TITLE
Bump envoy version to v1.19

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -26,8 +26,8 @@ jobs:
 
         gateway:
         - quay.io/maistra/proxyv2-ubi8:2.1.0
-        - docker.io/envoyproxy/envoy:v1.18-latest
         - docker.io/envoyproxy/envoy:v1.19-latest
+        - docker.io/envoyproxy/envoy:v1.20-latest
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -48,7 +48,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.18-latest
+          image: docker.io/envoyproxy/envoy:v1.19-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
As per title, this patch bumps the envoy image version included in the gateway.

**Release Note**

```release-note
kourier-gateway now updates envoy version to v1.19.
```

