### PR TITLE
Set `80` port if k8s service omits the port

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -143,9 +143,9 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 				// Match the ingress' port with a port on the Service to find the target.
 				// Also find out if the target supports HTTP2.
 				var (
-					externalPort int32
-					targetPort   int32
-					http2        bool
+					externalPort = int32(80)
+					targetPort   = int32(80)
+					http2        = false
 				)
 				for _, port := range service.Spec.Ports {
 					if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {


### PR DESCRIPTION
k8s's ExternalName type service can omit the port as
https://kubernetes.io/docs/concepts/services-networking/service/#externalname.

But current net-kourier assumes that it is `0` port if port was
omitted, then prober fails to probe.
This patch uses `80` port instead of `0` when it was omitted.

__Note__, the k8s service generated by ksvc does not omit the port. This
happens only when users point to the k8s service with ExternalName by
DomainMapping. Please see https://github.com/knative/serving/issues/12722 as well.

Fix https://github.com/knative/serving/issues/12722

```release-note
The bug which DomainMapping is not working with Knative Channel was fixed.
```
