### PR TITLE
Use HTTP2 when service has HTTP2 port in the ports

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -146,6 +146,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 					targetPort   int32
 					http2        bool
 				)
+
 				for _, port := range service.Spec.Ports {
 					if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
 						externalPort = port.Port

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -150,7 +150,9 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 					if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
 						externalPort = port.Port
 						targetPort = port.TargetPort.IntVal
-						http2 = port.Name == "http2" || port.Name == "h2c"
+					}
+					if port.Name == "http2" || port.Name == "h2c" {
+						http2 = true
 					}
 				}
 

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -146,7 +146,6 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 					targetPort   int32
 					http2        bool
 				)
-
 				for _, port := range service.Spec.Ports {
 					if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
 						externalPort = port.Port

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -892,6 +892,73 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 			}
 		}(),
 	}, {
+		name: "http and https",
+		in: ing("simplens", "simplename", func(ing *v1alpha1.Ingress) {
+			ing.Spec.Rules[0].HTTP.Paths[0].RewriteHost = ""
+			ing.Spec.Rules[0].HTTP.Paths[0].Splits[0].ServicePort = intstr.FromString("https")
+		}),
+		state: []runtime.Object{
+			svc("servicens", "servicename", func(service *corev1.Service) {
+				service.Spec.Ports = []corev1.ServicePort{{
+					Name:       "http",
+					TargetPort: intstr.FromInt(8080),
+				}, {
+					Name:       "https",
+					TargetPort: intstr.FromInt(443),
+				}}
+			}),
+			eps("servicens", "servicename"),
+			caSecret,
+		},
+		want: func() *translatedIngress {
+			vHosts := []*route.VirtualHost{
+				envoy.NewVirtualHost(
+					"(simplens/simplename).Rules[0]",
+					[]string{"foo.example.com", "foo.example.com:*"},
+					[]*route.Route{envoy.NewRoute(
+						"(simplens/simplename).Rules[0].Paths[/test]",
+						[]*route.HeaderMatcher{{
+							Name: "testheader",
+							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+								ExactMatch: "foo",
+							},
+						}},
+						"/test",
+						[]*route.WeightedCluster_ClusterWeight{
+							envoy.NewWeightedCluster("servicens/servicename", 100, map[string]string{"baz": "gna"}),
+						},
+						0,
+						map[string]string{"foo": "bar"},
+						""),
+					},
+				),
+			}
+
+			return &translatedIngress{
+				name: types.NamespacedName{
+					Namespace: "simplens",
+					Name:      "simplename",
+				},
+				sniMatches: []*envoy.SNIMatch{},
+				clusters: []*v3.Cluster{
+					envoy.NewCluster(
+						"servicens/servicename",
+						5*time.Second,
+						lbHTTPSEndpoints,
+						false, /* http2 */
+						&envoycorev3.TransportSocket{
+							Name:       wellknown.TransportSocketTls,
+							ConfigType: typedConfig(false /* http2 */),
+						},
+						v3.Cluster_STATIC,
+					),
+				},
+				externalVirtualHosts:    vHosts,
+				externalTLSVirtualHosts: []*route.VirtualHost{},
+				internalVirtualHosts:    vHosts,
+			}
+		}(),
+	}, {
 		name: "http2 and https",
 		in: ing("simplens", "simplename", func(ing *v1alpha1.Ingress) {
 			ing.Spec.Rules[0].HTTP.Paths[0].RewriteHost = ""

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -901,9 +901,11 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 			svc("servicens", "servicename", func(service *corev1.Service) {
 				service.Spec.Ports = []corev1.ServicePort{{
 					Name:       "http",
+					Port:       80,
 					TargetPort: intstr.FromInt(8080),
 				}, {
 					Name:       "https",
+					Port:       443,
 					TargetPort: intstr.FromInt(443),
 				}}
 			}),
@@ -968,9 +970,11 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 			svc("servicens", "servicename", func(service *corev1.Service) {
 				service.Spec.Ports = []corev1.ServicePort{{
 					Name:       "http2",
+					Port:       80,
 					TargetPort: intstr.FromInt(8080),
 				}, {
 					Name:       "https",
+					Port:       443,
 					TargetPort: intstr.FromInt(443),
 				}}
 			}),


### PR DESCRIPTION
https://github.com/knative/serving/pull/12770 will change the service to have multiple ports like this:

```
$ kubectl  get svc 
NAME                          TYPE           CLUSTER-IP     EXTERNAL-IP                                         PORT(S)                                              AGE
hello-example                 ExternalName   <none>         kourier-internal.kourier-system.svc.cluster.local   80/TCP                                               5h39m
hello-example-00001           ClusterIP      10.96.16.165   <none>                                              80/TCP,443/TCP                                       5h40m
hello-example-00001-private   ClusterIP      10.96.11.168   <none>                                              80/TCP,443/TCP,9090/TCP,9091/TCP,8022/TCP,8012/TCP   5h40m
```

and KIngress:

```
$ kubectl  get king  -o yaml
  ..
  spec:
    - hosts:
      - hello-example.default.example.com
      http:
        paths:
        - splits:
            serviceName: hello-example-00001
            serviceNamespace: default
            servicePort: 443
      visibility: ExternalIP
```

So, Kourier misses to use HTTP2 when the servicePort `443`. This patch fixes it.
