### PR TITLE
Skip re-load config from ctx

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -191,7 +191,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 				// As Ingress with RewriteHost points to ExternalService(kourier-internal), we don't enable TLS.
 				if activatorCA := cfg.Network.ActivatorCA; activatorCA != "" && httpPath.RewriteHost == "" {
 					var err error
-					transportSocket, err = translator.createUpstreamTransportSocket(activatorCA, config.FromContext(ctx).Network.ActivatorSAN, http2)
+					transportSocket, err = translator.createUpstreamTransportSocket(activatorCA, cfg.Network.ActivatorSAN, http2)
 					if err != nil {
 						return nil, err
 					}


### PR DESCRIPTION
As per title, this patch fixes a tiny redundant step. 