### PR TITLE
All Hops Encrypted: alpha Kourier support for encrypted for internal traffic

### DIFF
--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -51,9 +51,10 @@ data:
     enable-proxy-protocol: "false"
 
     # The server certificates to serve the internal TLS traffic for Kourier Gateway.
-    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
+    # It is specified by the secret name in controller namespace, which has
+    # the "tls.crt" and "tls.key" data field.
     # Use an empty value to disable the feature (default).
     #
     # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
     #       for now. Use with caution.
-    kourier-internal-cert-secret: ""
+    cluster-cert-secret: ""

--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -49,3 +49,11 @@ data:
     # across multiple layers of TCP proxies.
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
     enable-proxy-protocol: "false"
+
+    # The server certificates to serve the internal TLS traffic for Kourier Gateway.
+    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
+    # Use an empty value to disable the feature (default).
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    kourier-internal-cert-secret: ""

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -135,6 +135,10 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 8081
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8444
   selector:
     app: 3scale-kourier-gateway
   type: ClusterIP

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,12 +35,19 @@ const (
 
 	// HTTPPortExternal is the port for external availability.
 	HTTPPortExternal = uint32(8080)
+
 	// HTTPPortInternal is the port for internal availability.
 	HTTPPortInternal = uint32(8081)
+
+	// HTTPSPortInternal is the port for internal HTTPS availability.
+	HTTPSPortInternal = uint32(8444)
+
 	// HTTPSPortExternal is the port for external HTTPS availability.
 	HTTPSPortExternal = uint32(8443)
+
 	// HTTPPortProb is the port for prob
 	HTTPPortProb = uint32(8090)
+
 	// HTTPSPortProb is the port for prob
 	HTTPSPortProb = uint32(9443)
 

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -33,15 +33,15 @@ const (
 	// enableProxyProtocol is the config map key for enabling proxy protocol
 	enableProxyProtocol = "enable-proxy-protocol"
 
-	// kourierInternalCertSecret is the config map key for kourier internal certificates
-	kourierInternalCertSecret = "kourier-internal-cert-secret"
+	// clusterCertSecret is the config map key for kourier internal certificates
+	clusterCertSecret = "cluster-cert-secret"
 )
 
 func DefaultConfig() *Kourier {
 	return &Kourier{
 		EnableServiceAccessLogging: true, // true is the default for backwards-compat
 		EnableProxyProtocol:        false,
-		KourierInternalCertSecret:  "",
+		ClusterCertSecret:          "",
 	}
 }
 
@@ -52,7 +52,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 	if err := cm.Parse(configMap,
 		cm.AsBool(enableServiceAccessLoggingKey, &nc.EnableServiceAccessLogging),
 		cm.AsBool(enableProxyProtocol, &nc.EnableProxyProtocol),
-		cm.AsString(kourierInternalCertSecret, &nc.KourierInternalCertSecret),
+		cm.AsString(clusterCertSecret, &nc.ClusterCertSecret),
 	); err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ type Kourier struct {
 	EnableServiceAccessLogging bool
 	// EnableProxyProtocol specifies whether proxy protocol feature is enabled
 	EnableProxyProtocol bool
-	// KourierInternalCertSecret specifies the secret name for the server certificates of
+	// ClusterCertSecret specifies the secret name for the server certificates of
 	// Kourier Internal.
-	KourierInternalCertSecret string
+	ClusterCertSecret string
 }

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -33,8 +33,8 @@ const (
 	// enableProxyProtocol is the config map key for enabling proxy protocol
 	enableProxyProtocol = "enable-proxy-protocol"
 
-	// clusterCertSecret is the config map key for kourier internal certificates
-	clusterCertSecret = "cluster-cert-secret"
+	// clusterCert is the config map key for kourier internal certificates
+	clusterCert = "cluster-cert-secret"
 )
 
 func DefaultConfig() *Kourier {
@@ -52,7 +52,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 	if err := cm.Parse(configMap,
 		cm.AsBool(enableServiceAccessLoggingKey, &nc.EnableServiceAccessLogging),
 		cm.AsBool(enableProxyProtocol, &nc.EnableProxyProtocol),
-		cm.AsString(clusterCertSecret, &nc.ClusterCertSecret),
+		cm.AsString(clusterCert, &nc.ClusterCertSecret),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -32,12 +32,16 @@ const (
 
 	// enableProxyProtocol is the config map key for enabling proxy protocol
 	enableProxyProtocol = "enable-proxy-protocol"
+
+	// kourierInternalCertSecret is the config map key for kourier internal certificates
+	kourierInternalCertSecret = "kourier-internal-cert-secret"
 )
 
 func DefaultConfig() *Kourier {
 	return &Kourier{
 		EnableServiceAccessLogging: true, // true is the default for backwards-compat
 		EnableProxyProtocol:        false,
+		KourierInternalCertSecret:  "",
 	}
 }
 
@@ -48,6 +52,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 	if err := cm.Parse(configMap,
 		cm.AsBool(enableServiceAccessLoggingKey, &nc.EnableServiceAccessLogging),
 		cm.AsBool(enableProxyProtocol, &nc.EnableProxyProtocol),
+		cm.AsString(kourierInternalCertSecret, &nc.KourierInternalCertSecret),
 	); err != nil {
 		return nil, err
 	}
@@ -68,4 +73,7 @@ type Kourier struct {
 	EnableServiceAccessLogging bool
 	// EnableProxyProtocol specifies whether proxy protocol feature is enabled
 	EnableProxyProtocol bool
+	// KourierInternalCertSecret specifies the secret name for the server certificates of
+	// Kourier Internal.
+	KourierInternalCertSecret string
 }

--- a/pkg/config/configmap_test.go
+++ b/pkg/config/configmap_test.go
@@ -59,7 +59,7 @@ func TestKourierConfig(t *testing.T) {
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "true",
 			enableProxyProtocol:           "true",
-			clusterCertSecret:             "my-cert",
+			clusterCert:                   "my-cert",
 		},
 	}, {
 		name: "enable proxy protocol and disable logging, empty internal cert",
@@ -71,7 +71,7 @@ func TestKourierConfig(t *testing.T) {
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "false",
 			enableProxyProtocol:           "true",
-			clusterCertSecret:             "",
+			clusterCert:                   "",
 		},
 	}, {
 		name:    "not a bool for proxy protocol",

--- a/pkg/config/configmap_test.go
+++ b/pkg/config/configmap_test.go
@@ -50,24 +50,28 @@ func TestKourierConfig(t *testing.T) {
 			enableServiceAccessLoggingKey: "foo",
 		},
 	}, {
-		name: "enable proxy protocol and logging",
+		name: "enable proxy protocol, logging and internal cert",
 		want: &Kourier{
 			EnableServiceAccessLogging: true,
 			EnableProxyProtocol:        true,
+			KourierInternalCertSecret:  "my-cert",
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "true",
 			enableProxyProtocol:           "true",
+			kourierInternalCertSecret:     "my-cert",
 		},
 	}, {
-		name: "enable proxy protocol and disable logging",
+		name: "enable proxy protocol and disable logging, empty internal cert",
 		want: &Kourier{
 			EnableServiceAccessLogging: false,
 			EnableProxyProtocol:        true,
+			KourierInternalCertSecret:  "",
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "false",
 			enableProxyProtocol:           "true",
+			kourierInternalCertSecret:     "",
 		},
 	}, {
 		name:    "not a bool for proxy protocol",

--- a/pkg/config/configmap_test.go
+++ b/pkg/config/configmap_test.go
@@ -54,24 +54,24 @@ func TestKourierConfig(t *testing.T) {
 		want: &Kourier{
 			EnableServiceAccessLogging: true,
 			EnableProxyProtocol:        true,
-			KourierInternalCertSecret:  "my-cert",
+			ClusterCertSecret:          "my-cert",
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "true",
 			enableProxyProtocol:           "true",
-			kourierInternalCertSecret:     "my-cert",
+			clusterCertSecret:             "my-cert",
 		},
 	}, {
 		name: "enable proxy protocol and disable logging, empty internal cert",
 		want: &Kourier{
 			EnableServiceAccessLogging: false,
 			EnableProxyProtocol:        true,
-			KourierInternalCertSecret:  "",
+			ClusterCertSecret:          "",
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "false",
 			enableProxyProtocol:           "true",
-			kourierInternalCertSecret:     "",
+			clusterCertSecret:             "",
 		},
 	}, {
 		name:    "not a bool for proxy protocol",

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -244,14 +244,14 @@ func generateListenersAndRouteConfigs(
 	listeners = append(listeners, probHTTPListener)
 
 	// Add internal listeners and routes when internal cert secret is specified.
-	if cfg.Kourier.KourierInternalCertSecret != "" {
+	if cfg.Kourier.ClusterCertSecret != "" {
 		internalTLSRouteConfig := envoy.NewRouteConfig(internalTLSRouteConfigName, clusterLocalVirtualHosts)
 		internalTLSManager := envoy.NewHTTPConnectionManager(internalTLSRouteConfig.Name, cfg.Kourier.EnableServiceAccessLogging, cfg.Kourier.EnableProxyProtocol)
 
 		internalHTTPSEnvoyListener, err := newInternalEnvoyListenerWithOneCert(
 			ctx, internalTLSManager, kubeclient,
 			cfg.Kourier.EnableProxyProtocol,
-			cfg.Kourier.KourierInternalCertSecret,
+			cfg.Kourier.ClusterCertSecret,
 		)
 
 		if err != nil {

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -25,6 +25,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/testing/protocmp"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -256,7 +257,8 @@ func TestTLSListenerWithInternalCertSecret(t *testing.T) {
 	testConfig := &rconfig.Config{
 		Network: &network.Config{},
 		Kourier: &config.Kourier{
-			ClusterCertSecret: "test-ca",
+			ClusterCertSecret:   "test-ca",
+			EnableProxyProtocol: true,
 		},
 	}
 
@@ -290,8 +292,8 @@ func TestTLSListenerWithInternalCertSecret(t *testing.T) {
 		assert.NilError(t, err)
 
 		tlsListener := snapshot.GetResources(resource.ListenerType)[envoy.CreateListenerName(config.HTTPSPortInternal)].(*listener.Listener)
-		filterChains := tlsListener.FilterChains
-		assert.Assert(t, len(filterChains) == 1)
+		assert.Assert(t, len(tlsListener.ListenerFilters) == 1)
+		assert.Assert(t, (tlsListener.ListenerFilters[0]).Name == wellknown.ProxyProtocol)
 	})
 }
 

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -251,12 +251,12 @@ func TestTLSListenerWithEnvCertsSecret(t *testing.T) {
 }
 
 // TestTLSListenerWithInternalCertSecret verfies that
-// filter is added when secret name is specified by kourier-internal-cert-secret.
+// filter is added when secret name is specified by cluster-cert-secret.
 func TestTLSListenerWithInternalCertSecret(t *testing.T) {
 	testConfig := &rconfig.Config{
 		Network: &network.Config{},
 		Kourier: &config.Kourier{
-			KourierInternalCertSecret: "test-ca",
+			ClusterCertSecret: "test-ca",
 		},
 	}
 

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -27,10 +27,14 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"google.golang.org/protobuf/testing/protocmp"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"knative.dev/net-kourier/pkg/config"
 	envoy "knative.dev/net-kourier/pkg/envoy/api"
+	rconfig "knative.dev/net-kourier/pkg/reconciler/ingress/config"
+	network "knative.dev/networking/pkg"
 )
 
 func TestDeleteIngressInfo(t *testing.T) {
@@ -243,6 +247,51 @@ func TestTLSListenerWithEnvCertsSecret(t *testing.T) {
 		assert.Check(t, filterChainsByServerName["foo.example.com"] != nil)
 		assert.Check(t, filterChainsByServerName["bar.example.com"] != nil)
 		assert.Check(t, filterChainsByServerName[""] != nil) // filter chain without server name, "default" one
+	})
+}
+
+// TestTLSListenerWithInternalCertSecret verfies that
+// filter is added when secret name is specified by kourier-internal-cert-secret.
+func TestTLSListenerWithInternalCertSecret(t *testing.T) {
+	testConfig := &rconfig.Config{
+		Network: &network.Config{},
+		Kourier: &config.Kourier{
+			KourierInternalCertSecret: "test-ca",
+		},
+	}
+
+	internalSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ca",
+		},
+		Data: map[string][]byte{
+			caDataName: cert,
+		},
+	}
+
+	kubeClient := fake.Clientset{}
+	cfg := testConfig.DeepCopy()
+	ctx := (&testConfigStore{config: cfg}).ToContext(context.Background())
+
+	_, err := kubeClient.CoreV1().Secrets("knative-serving").Create(ctx, internalSecret, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	caches, err := NewCaches(ctx, &kubeClient, false)
+	assert.NilError(t, err)
+
+	t.Run("without SNI matches", func(t *testing.T) {
+		translatedIngress := &translatedIngress{
+			sniMatches: nil,
+		}
+		err := caches.addTranslatedIngress(translatedIngress)
+		assert.NilError(t, err)
+
+		snapshot, err := caches.ToEnvoySnapshot(ctx)
+		assert.NilError(t, err)
+
+		tlsListener := snapshot.GetResources(resource.ListenerType)[envoy.CreateListenerName(config.HTTPSPortInternal)].(*listener.Listener)
+		filterChains := tlsListener.FilterChains
+		assert.Assert(t, len(filterChains) == 1)
 	})
 }
 


### PR DESCRIPTION
Fix https://github.com/knative-sandbox/net-kourier/issues/805

As described in https://github.com/knative-sandbox/net-kourier/issues/805, service to service traffic does not
support TLS encryption. `kourier-internal` service does not even open the port.

This patch fixes it. 

/cc @skonto @rhuss
