### PR TITLE
Bump envoy version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,8 +25,8 @@ jobs:
 
         gateway:
         - quay.io/maistra/proxyv2-ubi8:2.1.0
-        - docker.io/envoyproxy/envoy:v1.19-latest
         - docker.io/envoyproxy/envoy:v1.20-latest
+        - docker.io/envoyproxy/envoy:v1.21-latest
 
         upstream-tls:
         - plain

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -47,7 +47,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.19-latest
+          image: docker.io/envoyproxy/envoy:v1.20-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
As per title, this patch bumps envoy version for testing and default in the manifest.

1.19 will be EOL soon https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#release-schedule.