### PR TITLE
Enable TLS on upgrade kind e2e

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -25,8 +25,7 @@ jobs:
 
         upstream-traffic:
         - plain
-        # TODO: Enable tls after 1.14 release.
-        # - tls
+        - tls
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
@@ -119,7 +118,7 @@ jobs:
         kind create cluster --config kind.yaml
 
     - name: Deploy certificates for upstream traffic
-      if: matrix.upstream-tls == 'tls'
+      if: matrix.upstream-traffic == 'tls'
       run: |
         set -o pipefail
         echo ">> Deploy certificate for upstream traffic"


### PR DESCRIPTION
As per tittle, this patch enables TLS on upgrade kind e2e.