### PR TITLE
Fixes #830

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ vars in the `net-kourier-controller` deployment:
 - `KOURIER_EXTAUTHZ_PATHPREFIX`: If `KOURIER_EXTAUTHZ_PROTOCOL` is equal to
   http or https, path to query the ext auth service. Example : if set to
   `/verify`, it will query `/verify/` (**notice the trailing `/`**).
-  If not set, it will query `/`.
-- `KOURIER_EXTAUTHZ_PACKASBYTES`: Sends the body as raw bytes instead of a UTF-8 string. Defaults to false. More info [Envoy Docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html?highlight=pack_as_bytes#extensions-filters-http-ext-authz-v3-buffersettings)
+  If not set, it will query `/`
+- `KOURIER_EXTAUTHZ_PACKASBYTES`: Sends the body as raw bytes instead of a UTF-8 string. Defaults to false. More info [Envoy Docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html?highlight=pack_as_bytes#extensions-filters-http-ext-authz-v3-buffersettings).
 
 `*` Required
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ vars in the `net-kourier-controller` deployment:
   http or https, path to query the ext auth service. Example : if set to
   `/verify`, it will query `/verify/` (**notice the trailing `/`**).
   If not set, it will query `/`
-- `KOURIER_EXTAUTHZ_PACKASBYTES`: Sends the body as raw bytes instead of a UTF-8 string. Defaults to false. More info [Envoy Docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html?highlight=pack_as_bytes#extensions-filters-http-ext-authz-v3-buffersettings).
+- `KOURIER_EXTAUTHZ_PACKASBYTES`: If `KOURIER_EXTAUTHZ_PROTOCOL` is equal to
+  grpc, sends the body as raw bytes instead of a UTF-8 string. Defaults to false. More info [Envoy Docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html?highlight=pack_as_bytes#extensions-filters-http-ext-authz-v3-buffersettings).
 
 `*` Required
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ vars in the `net-kourier-controller` deployment:
   http or https, path to query the ext auth service. Example : if set to
   `/verify`, it will query `/verify/` (**notice the trailing `/`**).
   If not set, it will query `/`.
+- `KOURIER_EXTAUTHZ_PACKASBYTES`: Sends the body as raw bytes instead of a UTF-8 string. Defaults to false. More info [Envoy Docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html?highlight=pack_as_bytes#extensions-filters-http-ext-authz-v3-buffersettings)
 
 `*` Required
 

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -184,7 +184,7 @@ func externalAuthZFilter(conf *config) *hcm.HttpFilter {
 		WithRequestBody: &extAuthService.BufferSettings{
 			MaxRequestBytes:     conf.MaxRequestBytes,
 			AllowPartialMessage: true,
-			PackAsBytes: conf.PackAsBytes
+			PackAsBytes: conf.PackAsBytes,
 		},
 		ClearRouteCache: false,
 	}

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -78,6 +78,7 @@ type config struct {
 	MaxRequestBytes  uint32           `default:"8192"`
 	Timeout          int              `default:"2000"`
 	Protocol         extAuthzProtocol `default:"grpc"`
+	PackAsBytes      bool             `default:"false"`
 	PathPrefix       string
 }
 
@@ -183,6 +184,7 @@ func externalAuthZFilter(conf *config) *hcm.HttpFilter {
 		WithRequestBody: &extAuthService.BufferSettings{
 			MaxRequestBytes:     conf.MaxRequestBytes,
 			AllowPartialMessage: true,
+			PackAsBytes: conf.PackAsBytes
 		},
 		ClearRouteCache: false,
 	}

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -184,9 +184,13 @@ func externalAuthZFilter(conf *config) *hcm.HttpFilter {
 		WithRequestBody: &extAuthService.BufferSettings{
 			MaxRequestBytes:     conf.MaxRequestBytes,
 			AllowPartialMessage: true,
-			PackAsBytes:         conf.PackAsBytes,
 		},
 		ClearRouteCache: false,
+	}
+
+	// Only set pack as bytes option if protocol is grpc
+	if conf.Protocol == extAuthzProtocolGRPC {
+		extAuthConfig.WithRequestBody.PackAsBytes = conf.PackAsBytes
 	}
 
 	headers := []*core.HeaderValue{{

--- a/pkg/config/ext_authz.go
+++ b/pkg/config/ext_authz.go
@@ -184,7 +184,7 @@ func externalAuthZFilter(conf *config) *hcm.HttpFilter {
 		WithRequestBody: &extAuthService.BufferSettings{
 			MaxRequestBytes:     conf.MaxRequestBytes,
 			AllowPartialMessage: true,
-			PackAsBytes: conf.PackAsBytes,
+			PackAsBytes:         conf.PackAsBytes,
 		},
 		ClearRouteCache: false,
 	}

--- a/pkg/config/ext_authz_test.go
+++ b/pkg/config/ext_authz_test.go
@@ -254,7 +254,7 @@ func Test_externalAuthZFilter_extAuthz(t *testing.T) {
 			},
 		},
 	}, {
-		name: "http with pack as bytes option",
+		name: "http with path prefix with pack bytes enabled",
 		conf: &config{
 			Host:            "example.com:8080",
 			MaxRequestBytes: 8192,

--- a/pkg/config/ext_authz_test.go
+++ b/pkg/config/ext_authz_test.go
@@ -254,7 +254,7 @@ func Test_externalAuthZFilter_extAuthz(t *testing.T) {
 			},
 		},
 	}, {
-		name: "http with path prefix",
+		name: "http with pack as bytes option",
 		conf: &config{
 			Host:            "example.com:8080",
 			MaxRequestBytes: 8192,
@@ -268,7 +268,6 @@ func Test_externalAuthZFilter_extAuthz(t *testing.T) {
 			WithRequestBody: &extAuthService.BufferSettings{
 				MaxRequestBytes:     8192,
 				AllowPartialMessage: true,
-				PackAsBytes:         true,
 			},
 			Services: &extAuthService.ExtAuthz_HttpService{
 				HttpService: &extAuthService.HttpService{

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -70,7 +70,7 @@ go test -race -count=1 -timeout=20m -tags=e2e ./test/cert/... \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"
 
-KOURIER_EXTAUTHZ_PROTOCOL=grpc
+export "KOURIER_EXTAUTHZ_PROTOCOL=grpc"
 
 echo ">> Setup ExtAuthz gRPC"
 ko apply -f test/config/extauthz/grpc
@@ -105,7 +105,7 @@ echo ">> Unset ExtAuthz gRPC"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PACKASBYTES-
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
-KOURIER_EXTAUTHZ_PROTOCOL=http
+export "KOURIER_EXTAUTHZ_PROTOCOL=http"
 
 echo ">> Setup ExtAuthz HTTP"
 ko apply -f test/config/extauthz/http
@@ -144,7 +144,7 @@ echo ">> Unset ExtAuthz HTTP with path prefix"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PROTOCOL- KOURIER_EXTAUTHZ_PATHPREFIX-
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
-unset KOURIER_EXTAUTHZ_PROTOCOL
+unset "KOURIER_EXTAUTHZ_PROTOCOL"
 
 echo ">> Setup Proxy Protocol"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type merge -p '{"data":{"enable-proxy-protocol":"true"}}'

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -70,6 +70,8 @@ go test -race -count=1 -timeout=20m -tags=e2e ./test/cert/... \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"
 
+KOURIER_EXTAUTHZ_PROTOCOL=grpc
+
 echo ">> Setup ExtAuthz gRPC"
 ko apply -f test/config/extauthz/grpc
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/externalauthz-grpc
@@ -94,7 +96,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-control
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
-KOURIER_EXTAUTHZ_PACKASBYTES_TEST=1 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
+KOURIER_EXTAUTHZ_PACKASBYTES=1 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"
@@ -103,12 +105,14 @@ echo ">> Unset ExtAuthz gRPC"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PACKASBYTES-
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
+KOURIER_EXTAUTHZ_PROTOCOL=http
+
 echo ">> Setup ExtAuthz HTTP"
 ko apply -f test/config/extauthz/http
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/externalauthz-http
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller \
   KOURIER_EXTAUTHZ_HOST=externalauthz-http.knative-serving:8080 \
-  KOURIER_EXTAUTHZ_PROTOCOL=http
+  KOURIER_EXTAUTHZ_PROTOCOL="$KOURIER_EXTAUTHZ_PROTOCOL"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
@@ -121,30 +125,12 @@ echo ">> Unset ExtAuthz HTTP"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PROTOCOL-
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
-echo ">> Setup ExtAuthz HTTP with pack as bytes option"
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller \
-  KOURIER_EXTAUTHZ_HOST=externalauthz-http.knative-serving:8080 \
-  KOURIER_EXTAUTHZ_PROTOCOL=http \
-  KOURIER_EXTAUTHZ_PACKASBYTES=true
-
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
-
-echo ">> Running ExtAuthz tests"
-KOURIER_EXTAUTHZ_PACKASBYTES_TEST=1 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
-  --ingressendpoint="${IPS[0]}" \
-  --ingressClass=kourier.ingress.networking.knative.dev \
-  --cluster-suffix="$CLUSTER_SUFFIX"
-
-echo ">> Unset ExtAuthz gRPC"
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PROTOCOL- KOURIER_EXTAUTHZ_PACKASBYTES-
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
-
 echo ">> Setup ExtAuthz HTTP with path prefix"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment externalauthz-http PATH_PREFIX="/check"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/externalauthz-http
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller \
   KOURIER_EXTAUTHZ_HOST=externalauthz-http.knative-serving:8080 \
-  KOURIER_EXTAUTHZ_PROTOCOL=http \
+  KOURIER_EXTAUTHZ_PROTOCOL="$KOURIER_EXTAUTHZ_PROTOCOL" \
   KOURIER_EXTAUTHZ_PATHPREFIX="/check"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
@@ -157,6 +143,8 @@ go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
 echo ">> Unset ExtAuthz HTTP with path prefix"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PROTOCOL- KOURIER_EXTAUTHZ_PATHPREFIX-
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
+
+unset KOURIER_EXTAUTHZ_PROTOCOL
 
 echo ">> Setup Proxy Protocol"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type merge -p '{"data":{"enable-proxy-protocol":"true"}}'

--- a/test/extauthz/extauthz_test.go
+++ b/test/extauthz/extauthz_test.go
@@ -82,8 +82,8 @@ func TestExtAuthz(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-	// When POSTing binary data, without KOURIER_EXTAUTHZ_PACKASBYTES, the result is "Forbidden"
-	// Because data passed to ext-authz service cannot be serialized. See https://github.com/knative-sandbox/net-kourier/issues/830
+	// When POSTing binary data with a gRPC ext-authz, without KOURIER_EXTAUTHZ_PACKASBYTES, the result is "Forbidden"
+	// Because data passed to ext-authz gRPC service cannot be serialized. See https://github.com/knative-sandbox/net-kourier/issues/830
 	// TODO: is this behavior expected? Should we keep this test or make KOURIER_EXTAUTHZ_PACKASBYTES the default behavior?
 	req, err = http.NewRequest("POST", "http://"+name+".example.com/success", bytes.NewReader([]byte{0x04, 0xf1}))
 	if err != nil {
@@ -95,7 +95,7 @@ func TestExtAuthz(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	if os.Getenv("KOURIER_EXTAUTHZ_PACKASBYTES_TEST") == "" {
+	if os.Getenv("KOURIER_EXTAUTHZ_PROTOCOL") == "grpc" && os.Getenv("KOURIER_EXTAUTHZ_PACKASBYTES") == "" {
 		assert.Equal(t, resp.StatusCode, http.StatusForbidden)
 	} else {
 		assert.Equal(t, resp.StatusCode, http.StatusOK)

--- a/test/extauthz/extauthz_test.go
+++ b/test/extauthz/extauthz_test.go
@@ -84,7 +84,6 @@ func TestExtAuthz(t *testing.T) {
 
 	// When POSTing binary data with a gRPC ext-authz, without KOURIER_EXTAUTHZ_PACKASBYTES, the result is "Forbidden"
 	// Because data passed to ext-authz gRPC service cannot be serialized. See https://github.com/knative-sandbox/net-kourier/issues/830
-	// TODO: is this behavior expected? Should we keep this test or make KOURIER_EXTAUTHZ_PACKASBYTES the default behavior?
 	req, err = http.NewRequest("POST", "http://"+name+".example.com/success", bytes.NewReader([]byte{0x04, 0xf1}))
 	if err != nil {
 		t.Fatal(err)

--- a/test/extauthz/extauthz_test.go
+++ b/test/extauthz/extauthz_test.go
@@ -20,8 +20,10 @@ limitations under the License.
 package extauthz
 
 import (
+	"bytes"
 	"context"
 	"net/http"
+	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -79,4 +81,23 @@ func TestExtAuthz(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	// When POSTing binary data, without KOURIER_EXTAUTHZ_PACKASBYTES, the result is "Forbidden"
+	// Because data passed to ext-authz service cannot be serialized. See https://github.com/knative-sandbox/net-kourier/issues/830
+	// TODO: is this behavior expected? Should we keep this test or make KOURIER_EXTAUTHZ_PACKASBYTES the default behavior?
+	req, err = http.NewRequest("POST", "http://"+name+".example.com/success", bytes.NewReader([]byte{0x04, 0xf1}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if os.Getenv("KOURIER_EXTAUTHZ_PACKASBYTES_TEST") == "" {
+		assert.Equal(t, resp.StatusCode, http.StatusForbidden)
+	} else {
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
+	}
 }


### PR DESCRIPTION
I've just added a very minor change that will fix #830.
Haven't written any tests for this. I'm not great with writing tests in Go and might need more help here.
I've set the default value of `KOURIER_EXTAUTHZ_PACKASBYTES` to false so that it doesn't break any existing applications, so I'm expecting all the existing tests to pass 🤞.

In the future, I think that having a mechanism to pass such configuration parameters directly to Envoy would be great.