### PR TITLE
Set no limit to the timeout by default

### DIFF
--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -60,7 +60,8 @@ data:
     cluster-cert-secret: ""
 
     # Specifies the amount of time that Kourier waits for the incoming requests.
-    stream-idle-timeout: "infinity"
+    # The default, 0s, imposes no timeout at all.
+    stream-idle-timeout: "0s"
 
     # Control the desired level of incoming traffic isolation.
     #

--- a/config/200-config.yaml
+++ b/config/200-config.yaml
@@ -60,7 +60,7 @@ data:
     cluster-cert-secret: ""
 
     # Specifies the amount of time that Kourier waits for the incoming requests.
-    stream-idle-timeout: "300s"
+    stream-idle-timeout: "infinity"
 
     # Control the desired level of incoming traffic isolation.
     #

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +70,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 		cm.AsBool(enableServiceAccessLoggingKey, &nc.EnableServiceAccessLogging),
 		cm.AsBool(enableProxyProtocol, &nc.EnableProxyProtocol),
 		cm.AsString(clusterCert, &nc.ClusterCertSecret),
-		asKourierDuration(IdleTimeoutKey, &nc.IdleTimeout),
+		cm.AsDuration(IdleTimeoutKey, &nc.IdleTimeout),
 		cm.AsString(trafficIsolation, (*string)(&nc.TrafficIsolation)),
 	); err != nil {
 		return nil, err
@@ -104,22 +103,4 @@ type Kourier struct {
 	IdleTimeout time.Duration
 	// Desire level of incoming traffic isolation
 	TrafficIsolation TrafficIsolationType
-}
-
-func asKourierDuration(key string, target *time.Duration) cm.ParseFunc {
-	return func(data map[string]string) error {
-		if raw, ok := data[key]; ok {
-			if raw == "infinity" {
-				notimeout := 0 * time.Second
-				*target = notimeout
-			} else {
-				timeout, err := time.ParseDuration(raw)
-				if err != nil {
-					return fmt.Errorf("failed to parse %q: %w", key, err)
-				}
-				*target = timeout
-			}
-		}
-		return nil
-	}
 }

--- a/pkg/config/configmap.go
+++ b/pkg/config/configmap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func DefaultConfig() *Kourier {
 		EnableServiceAccessLogging: true, // true is the default for backwards-compat
 		EnableProxyProtocol:        false,
 		ClusterCertSecret:          "",
-		IdleTimeout:                300 * time.Second, // default value
+		IdleTimeout:                0 * time.Second, // default value
 		TrafficIsolation:           "",
 	}
 }
@@ -70,7 +71,7 @@ func NewConfigFromMap(configMap map[string]string) (*Kourier, error) {
 		cm.AsBool(enableServiceAccessLoggingKey, &nc.EnableServiceAccessLogging),
 		cm.AsBool(enableProxyProtocol, &nc.EnableProxyProtocol),
 		cm.AsString(clusterCert, &nc.ClusterCertSecret),
-		cm.AsDuration(IdleTimeoutKey, &nc.IdleTimeout),
+		asKourierDuration(IdleTimeoutKey, &nc.IdleTimeout),
 		cm.AsString(trafficIsolation, (*string)(&nc.TrafficIsolation)),
 	); err != nil {
 		return nil, err
@@ -103,4 +104,22 @@ type Kourier struct {
 	IdleTimeout time.Duration
 	// Desire level of incoming traffic isolation
 	TrafficIsolation TrafficIsolationType
+}
+
+func asKourierDuration(key string, target *time.Duration) cm.ParseFunc {
+	return func(data map[string]string) error {
+		if raw, ok := data[key]; ok {
+			if raw == "infinity" {
+				notimeout := 0 * time.Second
+				*target = notimeout
+			} else {
+				timeout, err := time.ParseDuration(raw)
+				if err != nil {
+					return fmt.Errorf("failed to parse %q: %w", key, err)
+				}
+				*target = timeout
+			}
+		}
+		return nil
+	}
 }

--- a/pkg/config/configmap_test.go
+++ b/pkg/config/configmap_test.go
@@ -41,7 +41,7 @@ func TestKourierConfig(t *testing.T) {
 		name: "disable logging",
 		want: &Kourier{
 			EnableServiceAccessLogging: false,
-			IdleTimeout:                300 * time.Second,
+			IdleTimeout:                0 * time.Second,
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "false",
@@ -58,7 +58,7 @@ func TestKourierConfig(t *testing.T) {
 			EnableServiceAccessLogging: true,
 			EnableProxyProtocol:        true,
 			ClusterCertSecret:          "my-cert",
-			IdleTimeout:                300 * time.Second,
+			IdleTimeout:                0 * time.Second,
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "true",
@@ -71,7 +71,7 @@ func TestKourierConfig(t *testing.T) {
 			EnableServiceAccessLogging: false,
 			EnableProxyProtocol:        true,
 			ClusterCertSecret:          "",
-			IdleTimeout:                300 * time.Second,
+			IdleTimeout:                0 * time.Second,
 		},
 		data: map[string]string{
 			enableServiceAccessLoggingKey: "false",
@@ -104,7 +104,7 @@ func TestKourierConfig(t *testing.T) {
 			EnableServiceAccessLogging: true,
 			EnableProxyProtocol:        false,
 			ClusterCertSecret:          "",
-			IdleTimeout:                300 * time.Second,
+			IdleTimeout:                0 * time.Second,
 			TrafficIsolation:           "port",
 		},
 		data: map[string]string{

--- a/pkg/envoy/api/http_connection_manager_test.go
+++ b/pkg/envoy/api/http_connection_manager_test.go
@@ -35,7 +35,7 @@ func TestNewHTTPConnectionManagerWithoutAccessLogWithoutProxyProtocol(t *testing
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: false,
 		EnableProxyProtocol:        false,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	connManager := NewHTTPConnectionManager("test", &kourierConfig)
 	assert.Check(t, len(connManager.AccessLog) == 0)
@@ -46,7 +46,7 @@ func TestNewHTTPConnectionManagerWithAccessLogWithoutProxyProtocol(t *testing.T)
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        false,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	connManager := NewHTTPConnectionManager("test", &kourierConfig)
 	assert.Check(t, connManager.UseRemoteAddress == nil)
@@ -66,7 +66,7 @@ func TestNewHTTPConnectionManagerWithoutAccessLogWithProxyProtocol(t *testing.T)
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: false,
 		EnableProxyProtocol:        true,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	connManager := NewHTTPConnectionManager("test", &kourierConfig)
 	assert.Check(t, len(connManager.AccessLog) == 0)
@@ -78,7 +78,7 @@ func TestNewHTTPConnectionManagerWithAccessLogWithProxyProtocol(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        true,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	connManager := NewHTTPConnectionManager("test", &kourierConfig)
 	assert.Check(t, connManager.UseRemoteAddress != nil)

--- a/pkg/envoy/api/listener_test.go
+++ b/pkg/envoy/api/listener_test.go
@@ -40,7 +40,7 @@ func TestNewHTTPListener(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        false,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	manager := NewHTTPConnectionManager("test", &kourierConfig)
 
@@ -60,7 +60,7 @@ func TestNewHTTPListenerWithProxyProtocol(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        true,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	manager := NewHTTPConnectionManager("test", &kourierConfig)
 
@@ -80,7 +80,7 @@ func TestNewHTTPSListener(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        false,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	manager := NewHTTPConnectionManager("test", &kourierConfig)
 
@@ -112,7 +112,7 @@ func TestNewHTTPSListenerWithProxyProtocol(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        true,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	manager := NewHTTPConnectionManager("test", &kourierConfig)
 
@@ -154,7 +154,7 @@ func TestNewHTTPSListenerWithSNI(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        false,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	manager := NewHTTPConnectionManager("test", &kourierConfig)
 	listener, err := NewHTTPSListenerWithSNI(manager, 8443, sniMatches, false)
@@ -186,7 +186,7 @@ func TestNewHTTPSListenerWithSNIWithProxyProtocol(t *testing.T) {
 	kourierConfig := config.Kourier{
 		EnableServiceAccessLogging: true,
 		EnableProxyProtocol:        true,
-		IdleTimeout:                300 * time.Second,
+		IdleTimeout:                0 * time.Second,
 	}
 	manager := NewHTTPConnectionManager("test", &kourierConfig)
 	listener, err := NewHTTPSListenerWithSNI(manager, 8443, sniMatches, true)


### PR DESCRIPTION
Fixes #874 

# Changes
Change the default value of timeout to "infinity".

**Release Note**
```release-note
The timeout can be configured via stream-idle-timeout in config-kourier, the default value is set to "infinity" which means there is no timeout. 
Users can change this value in config-kourier with decimal numbers plus a unit suffix such as "ns", "us" (or "µs"), "ms", "s", "m", "h"
```

