### PR TITLE
Made TLS 1.2 the minimum protocol version

### DIFF
--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -217,6 +217,9 @@ func createTLSContext(certificate []byte, privateKey []byte) *auth.DownstreamTls
 	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			AlpnProtocols: []string{"h2", "http/1.1"},
+			TlsParams: &auth.TlsParameters{
+				TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+			},
 			TlsCertificates: []*auth.TlsCertificate{{
 				CertificateChain: &core.DataSource{
 					Specifier: &core.DataSource_InlineBytes{InlineBytes: certificate},

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -217,6 +217,7 @@ func createTLSContext(certificate []byte, privateKey []byte) *auth.DownstreamTls
 	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			AlpnProtocols: []string{"h2", "http/1.1"},
+			// Temporary fix until we start using envoyproxy image newer than v1.23.0 (envoyproxy has adopted TLS v1.2 as the default minimum version in https://github.com/envoyproxy/envoy/commit/f8baa480ec9c6cbaa7a9d5433102efb04145cfc8)
 			TlsParams: &auth.TlsParameters{
 				TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
- Set TLS v1.2 as the default minimal version 

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

As per https://github.com/knative-sandbox/net-kourier/pull/442#issuecomment-790291021, TLS 1.2 should be the default version. envoyproxy has adopted this change in https://github.com/envoyproxy/envoy/commit/f8baa480ec9c6cbaa7a9d5433102efb04145cfc8 (v1.23) - however, Kourier is still using [v1.20](https://github.com/knative-sandbox/net-kourier/blob/09b107be00adb153ef413e6de84c8b3f39b2c9b6/config/300-gateway.yaml#L50).
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
set TLS v1.2 as the default minimal version 
```
