### PR TITLE
Enable internal tls test on upgrade e2e

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -26,8 +26,7 @@ jobs:
 
         upstream-traffic:
         - plain
-        # TODO: Enable tls after 1.16 release.
-        # - tls
+        - tls
 
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.


### PR DESCRIPTION
As per title, this patch enables internal TLS on upgrade e2e.