### PR TITLE
Drop namespace from net-kourier ClusterRole

### DIFF
--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -27,7 +27,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: net-kourier
-  namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier


### PR DESCRIPTION
# Changes
- :broom: Drop namespace from net-kourier ClusterRole

/kind cleanup

Fixes #916 

**Release Note**

```release-note
Drop namespace from net-kourier ClusterRole for better compatibility with Kubernetes Provider for Terraform
```

