### PR TITLE
Add keepalive config in bootstrap.yaml

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -83,6 +83,16 @@ data:
                     pipe:
                       path: /tmp/envoy.admin
         - name: xds_cluster
+          # This keepalive is recommended by envoy docs.
+          # https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options:
+                  connection_keepalive:
+                    interval: 30s
+                    timeout: 5s
           connect_timeout: 1s
           type: strict_dns
           load_assignment:


### PR DESCRIPTION
As per title, this patch adds the keepalive configuration recommended by
https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol. 

**Release Note**

```release-note
keepalive config for xDS is added in `kourier-bootstrap` by default. 
```
