### PR TITLE
Bump envoy image to 1.21 and add compatibility with 1.22

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -26,8 +26,8 @@ jobs:
 
         gateway:
         - quay.io/maistra/proxyv2-ubi8:2.1.0
-        - docker.io/envoyproxy/envoy:v1.20-latest
         - docker.io/envoyproxy/envoy:v1.21-latest
+        - docker.io/envoyproxy/envoy:v1.22-latest
 
         upstream-tls:
         - plain

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -55,6 +55,8 @@ data:
                     stat_prefix: stats_server
                     http_filters:
                       - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     route_config:
                       virtual_hosts:
                         - name: admin_interface
@@ -101,3 +103,8 @@ data:
       address:
         pipe:
           path: /tmp/envoy.admin
+    layered_runtime:
+      layers:
+        - name: static-layer
+          static_layer:
+            envoy.reloadable_features.override_request_timeout_by_gateway_timeout: false

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -47,7 +47,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.20-latest
+          image: docker.io/envoyproxy/envoy:v1.21-latest
           name: kourier-gateway
           ports:
             - name: http2-external

--- a/pkg/envoy/api/http_connection_manager.go
+++ b/pkg/envoy/api/http_connection_manager.go
@@ -45,6 +45,9 @@ func NewHTTPConnectionManager(routeConfigName string, kourierConfig *config.Kour
 	// Append the Router filter at the end.
 	filters = append(filters, &hcm.HttpFilter{
 		Name: wellknown.Router,
+		ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: &anypb.Any{
+			TypeUrl: "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+		}},
 	})
 	enableAccessLog := kourierConfig.EnableServiceAccessLogging
 	enableProxyProtocol := kourierConfig.EnableProxyProtocol

--- a/pkg/envoy/api/listener.go
+++ b/pkg/envoy/api/listener.go
@@ -139,6 +139,9 @@ func NewHTTPSListenerWithSNI(manager *hcm.HttpConnectionManager, port uint32, sn
 		// detect requested SNI.
 		// Ref: https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/sni.html
 		Name: wellknown.TlsInspector,
+		ConfigType: &listener.ListenerFilter_TypedConfig{TypedConfig: &anypb.Any{
+			TypeUrl: "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector",
+		}},
 	}
 
 	listenerFilter = append(listenerFilter, listenerFilterForTLS)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Bump envoy image to v1.21 and update kind-e2e.yaml to test against v1.21 and v.1.22.

Currently gateway API uses envoy image is 1.20, but it will be EOL soon https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#major-release-schedule

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind enhancement

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #907 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Bump Envoy version to v1.21 for Kourier gateway.
```

