### PR TITLE
Remove deprecated empty fields in bootstrap.yaml

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -96,7 +96,6 @@ data:
                     interval: 30s
                     timeout: 5s
           connect_timeout: 1s
-          type: strict_dns
           load_assignment:
             cluster_name: xds_cluster
             endpoints:
@@ -106,7 +105,6 @@ data:
                     socket_address:
                       address: "net-kourier-controller.knative-serving"
                       port_value: 18000
-          http2_protocol_options: {}
           type: STRICT_DNS
     admin:
       access_log_path: "/dev/stdout"


### PR DESCRIPTION
### Changes

As mentioned in https://github.com/knative-sandbox/net-kourier/pull/920, there are some deprecated empty configurations are remained, which makes confusion.

This patch cleans up them.

- :broom: Update or clean up current behavior
