### PR TITLE
Run envoy as non-root

### DIFF
--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -68,7 +68,9 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
-            runAsNonRoot: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             capabilities:
               drop:
                 - ALL


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Runs envoy as non-root, similar to https://github.com/projectcontour/contour/pull/4084
- On OCP we use non-root for [some time](https://github.com/openshift-knative/serverless-operator/blob/1046d153bdd1bb4ba223386a3f54a2757b8d640c/openshift-knative-operator/cmd/operator/kodata/ingress/1.4/0-kourier.yaml#L430).
-  Tested on kind 1.25 with restricted PSP:
```
  kubectl create ns kourier-system
  kubectl label --overwrite ns kourier-system\
    pod-security.kubernetes.io/enforce=restricted \
    pod-security.kubernetes.io/warn=restricted \
    pod-security.kubernetes.io/audit=restricted
$ oc get pods -n kourier-system
NAME                                      READY   STATUS    RESTARTS   AGE
3scale-kourier-gateway-85878884dd-4wp6n   1/1     Running   0          16m
```
