### PR TITLE
Fix deprecated warning

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -107,7 +107,10 @@ data:
                       port_value: 18000
           type: STRICT_DNS
     admin:
-      access_log_path: "/dev/stdout"
+      access_log:
+      - name: envoy.access_loggers.stdout
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
       address:
         pipe:
           path: /tmp/envoy.admin

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -342,11 +342,14 @@ func createUpstreamTLSContext(caCertificate []byte, alpnProtocols ...string) *tl
 							InlineBytes: caCertificate,
 						},
 					},
-					MatchSubjectAltNames: []*envoymatcherv3.StringMatcher{{
-						MatchPattern: &envoymatcherv3.StringMatcher_Exact{
-							Exact: certificates.FakeDnsName,
-						}},
-					},
+					MatchTypedSubjectAltNames: []*tls.SubjectAltNameMatcher{{
+						SanType: tls.SubjectAltNameMatcher_DNS,
+						Matcher: &envoymatcherv3.StringMatcher{
+							MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+								Exact: certificates.FakeDnsName,
+							},
+						},
+					}},
 				},
 			},
 		},

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -411,8 +411,13 @@ func matchHeadersFromHTTPPath(httpPath v1alpha1.HTTPIngressPath) []*route.Header
 			Name: header,
 		}
 		if matchType.Exact != "" {
-			matchHeader.HeaderMatchSpecifier = &route.HeaderMatcher_ExactMatch{
-				ExactMatch: matchType.Exact,
+
+			matchHeader.HeaderMatchSpecifier = &route.HeaderMatcher_StringMatch{
+				StringMatch: &envoymatcherv3.StringMatcher{
+					MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+						Exact: matchType.Exact,
+					},
+				},
 			}
 		}
 		matchHeaders = append(matchHeaders, matchHeader)

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -26,7 +26,6 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoymatcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/google/go-cmp/cmp"
@@ -1627,8 +1626,8 @@ func typedConfig(http2 bool) *envoycorev3.TransportSocket_TypedConfig {
 							InlineBytes: cert,
 						},
 					},
-					MatchTypedSubjectAltNames: []*tls.SubjectAltNameMatcher{{
-						SanType: tls.SubjectAltNameMatcher_DNS,
+					MatchTypedSubjectAltNames: []*auth.SubjectAltNameMatcher{{
+						SanType: auth.SubjectAltNameMatcher_DNS,
 						Matcher: &envoymatcherv3.StringMatcher{
 							MatchPattern: &envoymatcherv3.StringMatcher_Exact{
 								Exact: certificates.FakeDnsName,

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -26,6 +26,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoymatcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/google/go-cmp/cmp"
@@ -1626,11 +1627,14 @@ func typedConfig(http2 bool) *envoycorev3.TransportSocket_TypedConfig {
 							InlineBytes: cert,
 						},
 					},
-					MatchSubjectAltNames: []*envoymatcherv3.StringMatcher{{
-						MatchPattern: &envoymatcherv3.StringMatcher_Exact{
-							Exact: certificates.FakeDnsName,
-						}},
-					},
+					MatchTypedSubjectAltNames: []*tls.SubjectAltNameMatcher{{
+						SanType: tls.SubjectAltNameMatcher_DNS,
+						Matcher: &envoymatcherv3.StringMatcher{
+							MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+								Exact: certificates.FakeDnsName,
+							},
+						},
+					}},
 				},
 			},
 		},

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -70,9 +70,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(simplens/simplename).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
-							},
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								}},
 						}},
 						"/test",
 						[]*route.WeightedCluster_ClusterWeight{
@@ -130,8 +133,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -199,8 +206,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -221,8 +232,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test"),
@@ -286,8 +301,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -371,8 +390,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -444,8 +467,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/",
@@ -499,8 +526,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -555,8 +586,12 @@ func TestIngressTranslator(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -688,8 +723,12 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -758,8 +797,12 @@ func TestIngressTranslatorWithHTTPOptionDisabled(t *testing.T) {
 						"(testspace/testname).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -864,8 +907,12 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						"(simplens/simplename).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -933,8 +980,12 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						"(simplens/simplename).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -1003,8 +1054,12 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						"(simplens/simplename).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -1073,8 +1128,12 @@ func TestIngressTranslatorWithUpstreamTLS(t *testing.T) {
 						"(simplens/simplename).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",
@@ -1284,8 +1343,12 @@ func TestIngressTranslatorDomainMappingDisableHTTP2(t *testing.T) {
 						"(simplens/simplename).Rules[0].Paths[/test]",
 						[]*route.HeaderMatcher{{
 							Name: "testheader",
-							HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-								ExactMatch: "foo",
+							HeaderMatchSpecifier: &route.HeaderMatcher_StringMatch{
+								StringMatch: &envoymatcherv3.StringMatcher{
+									MatchPattern: &envoymatcherv3.StringMatcher_Exact{
+										Exact: "foo",
+									},
+								},
 							},
 						}},
 						"/test",


### PR DESCRIPTION
This patch fixes the following warning message:

```
[2022-10-27 04:14:05.527][1][warning][misc] [external/envoy/source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext Using deprecated option 'envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext.match_subject_alt_names' from file common.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
```

```
[2022-10-27 04:14:05.551][1][warning][misc] [external/envoy/source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.route.v3.HeaderMatcher Using deprecated option 'envoy.config.route.v3.HeaderMatcher.exact_match' from file route_components.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
```

```
[2022-10-27 04:15:42.325][1][warning][misc] [external/envoy/source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.bootstrap.v3.Admin Using deprecated option 'envoy.config.bootstrap.v3.Admin.access_log_path' from file bootstrap.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
```