### PR TITLE
drop setting seccomp profile

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -64,8 +64,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
       restartPolicy: Always
       serviceAccountName: net-kourier
 ---

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -74,8 +74,6 @@ spec:
             capabilities:
               drop:
                 - ALL
-            seccompProfile:
-              type: RuntimeDefault
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -88,5 +88,3 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault


### PR DESCRIPTION
This causes issues on clusters < 1.25 and can break upgrades
