### PR TITLE
Bump Maistra image version to 2.3

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,7 +24,7 @@ jobs:
         - v1.25.3
 
         gateway:
-        - quay.io/maistra/proxyv2-ubi8:2.1.0
+        - quay.io/maistra-dev/proxyv2-ubi8:2.3-daily # The image suffix will be added later.
         - docker.io/envoyproxy/envoy:v1.21-latest
         - docker.io/envoyproxy/envoy:v1.22-latest
 
@@ -121,6 +121,15 @@ jobs:
         echo ">> Deploy certificate for upstream traffic"
         ./test/generate-upstream-cert.sh
 
+    - name: Set current datetime as env variable for maistra image
+      id: image
+      run: |
+        if [[ "${{ matrix.gateway }}" =~ "maistra" ]]; then
+          echo "::set-output name=image::${{ matrix.gateway }}-$(date --date '1 day ago' +'%Y-%m-%d')"
+        else
+          echo "::set-output name=image::${{ matrix.gateway }}"
+        fi
+
     - name: Install Knative net-kourier
       run: |
         set -o pipefail
@@ -128,7 +137,7 @@ jobs:
         # Build and Publish our containers to the docker daemon (including test assets)
         ko resolve -f test/config/ -f config/ | \
           sed 's/LoadBalancer/NodePort/g' | \
-          sed "s|docker.io/envoyproxy/envoy:.*|${{ matrix.gateway }}|" | \
+          sed "s|docker.io/envoyproxy/envoy:.*|${{ steps.image.outputs.image }}|" | \
           kubectl apply -f -
 
     - name: Wait for Ready


### PR DESCRIPTION
This patch bumps maistra (Red Hat's Envoy image) to 2.3 in github action.