### PR TITLE
Add upgrade strategy

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -23,6 +23,11 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
   replicas: 1
   selector:
     matchLabels:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -27,7 +27,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
-      maxSurge: 1
+      maxSurge: 100%
   selector:
     matchLabels:
       app: 3scale-kourier-gateway


### PR DESCRIPTION
As per title, this patch adds upgrade strategy.

Downstream has been using [this strategy](https://github.com/openshift-knative/net-kourier/blob/release-1.8/openshift/release/download_release_artifacts.sh#L36-L38) and verified that it becomes stable.