### PR TITLE
Add prometheus annotations to net-kourier

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -34,6 +34,10 @@ spec:
       app: net-kourier-controller
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
       labels:
         app: net-kourier-controller
     spec:

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -39,6 +39,9 @@ spec:
         # v0.26 supports envoy v3 API, so
         # adding this label to restart pod.
         networking.knative.dev/poke: "v0.26"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9000"
+        prometheus.io/path: "/stats/prometheus"
     spec:
       containers:
         - args:


### PR DESCRIPTION
# Changes

Fixes #957 
- 🎁  Adds prometheus scrape annotations for both `controller` and `envoy` pods.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind enhancement

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->

**Release Note**

```release-note
* Adds prometheus scraping annotations for net-kourier, so Prometheus Operator users should now be able to collect statistics automatically.
```