### PR TITLE
Bump envoy version to 1.23 and 1.24

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,8 +25,8 @@ jobs:
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.3-latest
-        - docker.io/envoyproxy/envoy:v1.22-latest
         - docker.io/envoyproxy/envoy:v1.23-latest
+        - docker.io/envoyproxy/envoy:v1.24-latest
 
         upstream-tls:
         - plain

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -50,7 +50,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.22-latest
+          image: docker.io/envoyproxy/envoy:v1.23-latest
           name: kourier-gateway
           ports:
             - name: http2-external


### PR DESCRIPTION
As per title, this patch bump testing envoy version to 1.23 and 1.24.