### PR TITLE
Bump CI configs

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -22,6 +22,7 @@ jobs:
         k8s-version:
         - v1.24.7
         - v1.25.3
+        - v1.26.0
 
         upstream-traffic:
         - plain
@@ -39,6 +40,10 @@ jobs:
           kind-version: v0.17.0
           kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
 
+        - k8s-version: v1.26.0
+          kind-version: v0.17.0
+          kind-image-sha: sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+
     env:
       GOPATH: ${{ github.workspace }}
       KO_DOCKER_REPO: kind.local
@@ -48,10 +53,10 @@ jobs:
       KIND_CLUSTER_NAME: "kourier-integration"
 
     steps:
-    - name: Set up Go 1.18.x
+    - name: Set up Go 1.19.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - name: Install Dependencies
       working-directory: ./

--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -54,7 +54,8 @@ jobs:
 
     steps:
     - name: Set up Go 1.19.x
-      uses: actions/setup-go@v4
+      # TODO: https://github.com/knative-sandbox/net-kourier/issues/1020
+      uses: actions/setup-go@v2
       with:
         go-version: 1.19.x
 

--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.19.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19.x
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -27,8 +27,8 @@ jobs:
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.3-latest
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
+        - docker.io/envoyproxy/envoy:v1.23-latest
         - docker.io/envoyproxy/envoy:v1.24-latest
-        - docker.io/envoyproxy/envoy:v1.25-latest
 
         upstream-tls:
         - plain

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -22,11 +22,13 @@ jobs:
         k8s-version:
         - v1.24.7
         - v1.25.3
+        - v1.26.0
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.3-latest
-        - docker.io/envoyproxy/envoy:v1.23-latest
+        - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
         - docker.io/envoyproxy/envoy:v1.24-latest
+        - docker.io/envoyproxy/envoy:v1.25-latest
 
         upstream-tls:
         - plain
@@ -44,6 +46,10 @@ jobs:
           kind-version: v0.17.0
           kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
 
+        - k8s-version: v1.26.0
+          kind-version: v0.17.0
+          kind-image-sha: sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+
     env:
       GOPATH: ${{ github.workspace }}
       KO_DOCKER_REPO: kind.local
@@ -52,10 +58,10 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
 
     steps:
-    - name: Set up Go 1.18.x
+    - name: Set up Go 1.19.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - name: Setup ko
       uses: imjasonh/setup-ko@v0.6

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.19.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19.x
 


### PR DESCRIPTION
This patch bumps CI configs to:
- add k8s 1.26.
- updates Go 1.19 from 1.18.
- add proxyv2-ubi8:2.4
- ~~add envoy:v1.25 and drop envoy:v1.23.~~ https://github.com/knative-sandbox/net-kourier/issues/1015