### PR TITLE
:broom: Add debug log for cluster

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -217,6 +217,7 @@ func (translator *IngressTranslator) translateIngress(ctx context.Context, ingre
 					}
 				}
 				cluster := envoy.NewCluster(splitName, connectTimeout, publicLbEndpoints, http2, transportSocket, typ)
+				logger.Debugf("adding cluster: %v", cluster)
 				clusters = append(clusters, cluster)
 
 				weightedCluster := envoy.NewWeightedCluster(splitName, uint32(split.Percent), split.AppendHeaders)


### PR DESCRIPTION
`translateIngress()` translates Kingress basiclly but it fetches `endpoints`'s IP to generate cluster resource. The `endpoints`'s IP can be dynamically changed, for example when activator's IP address is added/deleted, and it is difficult to debug what IP was added to the Kourier Gateway. We can dump the Kourier Gateway but it also should be confirmed in the kourier controller side.

The debug logs with this PR:

```
{"severity":"DEBUG","timestamp":"2023-03-28T10:12:57.337238395Z","logger":"net-kourier-controller","caller":"generator/ingress_translator.go:220","message":"adding cluster: name:\"default/hello-example-00001\"  type:STATIC  connect_timeout:{seconds:5}  load_assignment:{cluster_name:\"default/hello-example-00001\"  endpoints:{lb_endpoints:{endpoint:{address:{socket_address:{address:\"10.244.1.2\"  port_value:8012  ipv4_compat:true}}}}}}","commit":"936f8e6-dirty","knative.dev/controller":"knative.dev.net-kourier.pkg.reconciler.ingress.Reconciler","knative.dev/kind":"networking.internal.knative.dev.Ingress","knative.dev/traceid":"bad69898-49aa-436a-b8de-dda1ac3affce","knative.dev/key":"default/hello-example"}
```
/kind cleanup

**Release Note**

```release-note
NONE
```
