### PR TITLE
Fix keepalive interval

### DIFF
--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -93,7 +93,7 @@ data:
               explicit_http_config:
                 http2_protocol_options:
                   connection_keepalive:
-                    interval: 30s
+                    interval: 300s
                     timeout: 5s
           connect_timeout: 1s
           load_assignment:

--- a/config/200-bootstrap.yaml
+++ b/config/200-bootstrap.yaml
@@ -93,7 +93,7 @@ data:
               explicit_http_config:
                 http2_protocol_options:
                   connection_keepalive:
-                    interval: 300s
+                    interval: 30s
                     timeout: 5s
           connect_timeout: 1s
           load_assignment:

--- a/pkg/envoy/server/xds_server.go
+++ b/pkg/envoy/server/xds_server.go
@@ -29,6 +29,7 @@ import (
 	xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"google.golang.org/grpc"
 	health "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 )
 
 const (
@@ -69,7 +70,10 @@ func (envoyXdsServer *XdsServer) RunManagementServer() error {
 	port := envoyXdsServer.managementPort
 	server := envoyXdsServer.server
 
-	grpcServer := grpc.NewServer(grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams))
+	grpcServer := grpc.NewServer(
+		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{PermitWithoutStream: true}),
+	)
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)

--- a/pkg/envoy/server/xds_server.go
+++ b/pkg/envoy/server/xds_server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -72,7 +73,7 @@ func (envoyXdsServer *XdsServer) RunManagementServer() error {
 
 	grpcServer := grpc.NewServer(
 		grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams),
-		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{PermitWithoutStream: true}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{MinTime: 20 * time.Second, PermitWithoutStream: true}),
 	)
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {


### PR DESCRIPTION
# Changes
- :bug: Extend keepalive interval.

/kind bug

# Why
After updating kourier from v1.5.0 to v1.9.2, warning logs appeared and `envoy_cluster_manager_cds_update_failure` was counted.
```
kourier-gateway [2023-04-04 05:06:31.483][1][warning][config] [./source/common/config/grpc_stream.h:160] StreamAggregatedResources gRPC config stream closed: 13,
```
I extended the keepalive interval to 5 min and it resolved.
refs: #920 

This setting may be related.
https://pkg.go.dev/google.golang.org/grpc/keepalive#EnforcementPolicy
```go
MinTime time.Duration // The current default value is 5 minutes.
```