### PR TITLE
Add missing probes

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -42,5 +42,5 @@ func main() {
 	}
 
 	ctx := informerfiltering.GetContextWithFilteringLabelSelector(signals.NewContext())
-	sharedmain.MainWithContext(ctx, config.ControllerName, kourierIngressController.NewController)
+	sharedmain.MainWithContext(sharedmain.WithHealthProbesDisabled(ctx), config.ControllerName, kourierIngressController.NewController)
 }

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -66,6 +66,9 @@ spec:
           readinessProbe:
             exec:
               command: ["/ko-app/kourier", "-probe-addr=:18000"]
+          livenessProbe:
+            exec:
+              command: [ "/ko-app/kourier", "-probe-addr=:18000" ]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -91,7 +91,17 @@ spec:
               httpHeaders:
                 - name: Host
                   value: internalkourier
-              path: /ready
+              path: /
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              httpHeaders:
+                - name: Host
+                  value: internalkourier
+              path: /
               port: 8081
               scheme: HTTP
             initialDelaySeconds: 10

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Generates an internal virtual host that signals that the Envoy instance has
-// been configured, this endpoint is used by the kubernetes readiness probe.
+// been configured, this endpoint is used by the kubernetes readiness, liveness probes.
 func statusVHost() *route.VirtualHost {
 	vhost := envoy.NewVirtualHost(
 		config.InternalKourierDomain,
@@ -54,7 +54,7 @@ func readyRoute() *route.Route {
 	cluster := envoy.NewWeightedCluster("service_stats", 100, nil)
 	var wrs []*route.WeightedCluster_ClusterWeight
 	wrs = append(wrs, cluster)
-	route := envoy.NewRoute("gateway_ready", nil, "/ready", wrs, 1*time.Second, nil, "")
+	route := envoy.NewRoute("gateway_ready", nil, "/", wrs, 1*time.Second, nil, "")
 
 	return route
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adds missing probes for net-kourier-controller and the gateway,
- changes the path to "/" so it can be used by both paths. Adding a separate path per probe can be more complex due to the cluster matching etc.