### PR TITLE
Add support for pack_as_bytes configuration for ext-authz

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ vars in the `net-kourier-controller` deployment:
 - `KOURIER_EXTAUTHZ_PATHPREFIX`: If `KOURIER_EXTAUTHZ_PROTOCOL` is equal to
   http or https, path to query the ext auth service. Example : if set to
   `/verify`, it will query `/verify/` (**notice the trailing `/`**).
-  If not set, it will query `/`.
+  If not set, it will query `/`
+- `KOURIER_EXTAUTHZ_PACKASBYTES`: If `KOURIER_EXTAUTHZ_PROTOCOL` is equal to
+  grpc, sends the body as raw bytes instead of a UTF-8 string. Accepts only true/false, t/f or 1/0.
+  Attempting to set another value will throw an error. Defaults to false. More info
+  [Envoy Docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto.html?highlight=pack_as_bytes#extensions-filters-http-ext-authz-v3-buffersettings).
 
 `*` Required
 

--- a/test/config/extauthz/grpc/src/main.go
+++ b/test/config/extauthz/grpc/src/main.go
@@ -36,7 +36,7 @@ type AuthV2 struct{}
 
 type AuthV3 struct{}
 
-func (ea AuthV3) Check(ctx context.Context, ar *authZ_v3.CheckRequest) (*authZ_v3.CheckResponse, error) {
+func (ea AuthV3) Check(_ context.Context, ar *authZ_v3.CheckRequest) (*authZ_v3.CheckResponse, error) {
 	if ar.Attributes.Request.Http.Path == "/success" || ar.Attributes.Request.Http.Path == "/healthz" {
 		log.Print("TRUE")
 		return &authZ_v3.CheckResponse{
@@ -56,7 +56,7 @@ func (ea AuthV3) Check(ctx context.Context, ar *authZ_v3.CheckRequest) (*authZ_v
 	}, nil
 }
 
-func (ea AuthV2) Check(ctx context.Context, ar *authZ_v2.CheckRequest) (*authZ_v2.CheckResponse, error) {
+func (ea AuthV2) Check(_ context.Context, ar *authZ_v2.CheckRequest) (*authZ_v2.CheckResponse, error) {
 	if ar.Attributes.Request.Http.Path == "/success" || ar.Attributes.Request.Http.Path == "/healthz" {
 		log.Print("TRUE")
 		return &authZ_v2.CheckResponse{

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -37,7 +37,7 @@ if [[ $(kubectl get secret server-certs -n "${TEST_NAMESPACE}" -o name | wc -l) 
   export "SERVER_NAME=data-plane.knative.dev"
 fi
 
-IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
+IPS=($(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'))
 
 export "GATEWAY_OVERRIDE=kourier"
 export "GATEWAY_NAMESPACE_OVERRIDE=${KOURIER_GATEWAY_NAMESPACE}"
@@ -67,7 +67,7 @@ echo ">> Running TLS Cipher suites"
 echo ">> Setup cipher suites"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type merge -p '{"data":{"cipher-suites":"ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-ECDSA-CHACHA20-POLY1305"}}'
 
-go test -v  -tags=e2e ./test/tls/... \
+go test -v -tags=e2e ./test/tls/... \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"
@@ -85,6 +85,8 @@ go test -race -count=1 -timeout=20m -tags=e2e ./test/cert/... \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"
 
+export "KOURIER_EXTAUTHZ_PROTOCOL=grpc"
+
 echo ">> Setup ExtAuthz gRPC"
 ko apply -f test/config/extauthz/grpc
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" wait --timeout=300s --for=condition=Available deployment/externalauthz-grpc
@@ -99,6 +101,23 @@ go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
 
 echo ">> Unset ExtAuthz gRPC"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST-
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
+
+echo ">> Setup ExtAuthz gRPC with pack as bytes option"
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller \
+  KOURIER_EXTAUTHZ_HOST=externalauthz-grpc.knative-serving:6000 \
+  KOURIER_EXTAUTHZ_PACKASBYTES=true
+
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
+
+echo ">> Running ExtAuthz tests"
+KOURIER_EXTAUTHZ_PACKASBYTES=1 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
+  --ingressendpoint="${IPS[0]}" \
+  --ingressClass=kourier.ingress.networking.knative.dev \
+  --cluster-suffix="$CLUSTER_SUFFIX"
+
+echo ">> Unset ExtAuthz gRPC"
+kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-controller KOURIER_EXTAUTHZ_HOST- KOURIER_EXTAUTHZ_PACKASBYTES-
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller
 
 echo ">> Setup ExtAuthz HTTP"

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -111,7 +111,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-control
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
-KOURIER_EXTAUTHZ_PACKASBYTES=1 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
+go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \
   --cluster-suffix="$CLUSTER_SUFFIX"

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -94,6 +94,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-control
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
+KOURIER_GATEWAY_IMAGE=$(kubectl get deployment -n kourier-system 3scale-kourier-gateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="kourier-gateway")].image}') \
 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -94,7 +94,7 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" set env deployment net-kourier-control
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running ExtAuthz tests"
-KOURIER_GATEWAY_IMAGE=$(kubectl get deployment -n kourier-system 3scale-kourier-gateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="kourier-gateway")].image}') \
+KOURIER_GATEWAY_IMAGE="$(kubectl get deployment -n ${KOURIER_GATEWAY_NAMESPACE} 3scale-kourier-gateway -o jsonpath='{.spec.template.spec.containers[?(@.name=="kourier-gateway")].image}')" \
 go test -race -count=1 -timeout=20m -tags=e2e ./test/extauthz/... \
   --ingressendpoint="${IPS[0]}" \
   --ingressClass=kourier.ingress.networking.knative.dev \

--- a/test/extauthz/extauthz_test.go
+++ b/test/extauthz/extauthz_test.go
@@ -81,10 +81,6 @@ func TestExtAuthz(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
 
-	// When POSTing binary data with a gRPC ext-authz, without KOURIER_EXTAUTHZ_PACKASBYTES, the result was "Forbidden" with Envoy <= 1.21
-	// This is because data passed to ext-authz gRPC service couldn't be serialized. See https://github.com/knative-sandbox/net-kourier/issues/830
-	// From Envoy >= 1.22, the result is now "Ok". However, even if data is sent to the ext-authz service, the data is not correctly serialized
-	// Every byte sent to the ext-authz in [128;255] range is received as 33
 	postBody := make([]byte, 256)
 	for i := 0; i < 256; i++ {
 		postBody[i] = byte(i)

--- a/test/extauthz/extauthz_test.go
+++ b/test/extauthz/extauthz_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -80,6 +81,14 @@ func TestExtAuthz(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	// TODO: Drop this skip after maistra 2.4 starts using Envoy 1.22.10 or later.
+	if os.Getenv("KOURIER_GATEWAY_IMAGE") == "quay.io/maistra-dev/proxyv2-ubi8:2.4-latest" {
+		t.Skip("Skip POSTing with binary data when using maistra-dev/proxyv2-ubi8:2.4-latest image, " +
+			"see https://github.com/knative-sandbox/net-kourier/pull/1039#issuecomment-1537426109 for details. " +
+			"There is a bug in older Envoy versions, and will be solved when maistra starts using Envoy 1.22.10 or later, " +
+			"specifically this commit: https://github.com/envoyproxy/envoy/commit/5ced3041fc2da22fcf72fd621ce432aa26024caa")
+	}
 
 	postBody := make([]byte, 256)
 	for i := 0; i < 256; i++ {


### PR DESCRIPTION
Supersedes #831. This #831 PR is opened for more than 1 year as of today, and making changes on it introduces a lot of delay, since I'm not the author and I need to synchronize with the original PR creator (I've made 3 PR there yet, and when CI tests are failing, I need to create another MR every time :disappointed:). I am currently running a fork of Kourier in production just for this change, so I'd like this to be merged upstream soon, and it can also profit other users. Thanks!

Credits also go to [sidharthramesh](https://github.com/sidharthramesh) who reported the issue and made the initial PR. I've added the tests (unit + integration), fix lint issues, doc, etc.

# Changes

:gift: Add support for pack_as_bytes configuration for ext-authz

When ext-authz uses grpc protocol, it's now possible to configure pack_as_bytes. This is necessary when the body sent to the external authorization service is raw bytes, and not an UTF-8 string.

By default, this value is set to `false`, so there is no breaking changes.

If users try to set `KOURIER_EXTAUTHZ_PACKASBYTES` to `true` if they are using the HTTP protocol for ext-authz, kourier will throw an error at startup. Indeed, pack as bytes option makes only sense when gRPC protocol is used.

/kind enhancement

Fixes #830

**Release Note**

```release-note
add support for pack_as_bytes configuration for ext-authz
```