### PR TITLE
Fix Secret and Service tracker

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -266,7 +266,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(
 		controller.EnsureTypeMeta(
 			impl.Tracker.OnChanged,
-			corev1.SchemeGroupVersion.WithKind("Services"),
+			corev1.SchemeGroupVersion.WithKind("Service"),
 		),
 	))
 
@@ -293,7 +293,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	secretInformer.Informer().AddEventHandler(controller.HandleAll(
 		controller.EnsureTypeMeta(
 			impl.Tracker.OnChanged,
-			corev1.SchemeGroupVersion.WithKind("Secrets"),
+			corev1.SchemeGroupVersion.WithKind("Secret"),
 		),
 	))
 


### PR DESCRIPTION
Currently controller has a tracker for Secret and Service but it is not triggered due to wrong plural (`s`).

This patch fixes it and make the tracker working when Secret or Service are changed.

```release-note
There is a bug which tracker was not triggered for Secret and Service. It is fixed now.
```
