### PR TITLE
Update github action for kind e2e and upgrade

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -20,29 +20,13 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.24.7
-        - v1.25.3
-        - v1.26.0
+        - v1.25.x
+        - v1.26.x
+        - v1.27.x
 
         upstream-traffic:
         - plain
         - tls
-
-        # Map between K8s and KinD versions.
-        # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases
-        include:
-        - k8s-version: v1.24.7
-          kind-version: v0.17.0
-          kind-image-sha: sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
-
-        - k8s-version: v1.25.3
-          kind-version: v0.17.0
-          kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
-
-        - k8s-version: v1.26.0
-          kind-version: v0.17.0
-          kind-image-sha: sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -59,14 +43,7 @@ jobs:
       with:
         go-version: 1.19.x
 
-    - name: Install Dependencies
-      working-directory: ./
-      run: |
-        echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_x86_64.tar.gz | tar xzf - ko
-        chmod +x ./ko
-        sudo mv ko /usr/local/bin
-        echo '::endgroup::'
+    - uses: imjasonh/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
@@ -75,52 +52,13 @@ jobs:
         # Fetch all tags to determine the latest release version.
         fetch-depth: 0
 
-    - name: Install KinD
-      run: |
-        set -x
-
-        # Disable swap otherwise memory enforcement doesn't work
-        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600009955324200
-        sudo swapoff -a
-        sudo rm -f /swapfile
-
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
-
     - name: Create KinD Cluster
-      run: |
-        set -x
-
-        # KinD configuration.
-        cat > kind.yaml <<EOF
-        apiVersion: kind.x-k8s.io/v1alpha4
-        kind: Cluster
-        nodes:
-        - role: control-plane
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-        - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-
-        # This is needed in order to
-        # (1) support projected volumes with service account tokens. See
-        #     https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
-        # (2) use a random cluster suffix
-        kubeadmConfigPatches:
-          - |
-            kind: ClusterConfiguration
-            metadata:
-              name: config
-            apiServer:
-              extraArgs:
-                "service-account-issuer": "kubernetes.default.svc"
-                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-            networking:
-              dnsDomain: "${CLUSTER_SUFFIX}"
-        EOF
-
-        # Create a cluster!
-        kind create cluster --config kind.yaml
+      uses: chainguard-dev/actions/setup-kind@main
+      id: kind
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+        kind-worker-count: 1
+        cluster-suffix: "${CLUSTER_SUFFIX}"
 
     - name: Deploy certificates for upstream traffic
       if: matrix.upstream-traffic == 'tls'

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.24.7
-        - v1.25.3
-        - v1.26.0
+        - v1.25.x
+        - v1.26.x
+        - v1.27.x
 
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.3-latest
@@ -33,22 +33,6 @@ jobs:
         upstream-tls:
         - plain
         - tls
-
-        # Map between K8s and KinD versions.
-        # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases
-        include:
-        - k8s-version: v1.24.7
-          kind-version: v0.17.0
-          kind-image-sha: sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
-
-        - k8s-version: v1.25.3
-          kind-version: v0.17.0
-          kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
-
-        - k8s-version: v1.26.0
-          kind-version: v0.17.0
-          kind-image-sha: sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -63,62 +47,19 @@ jobs:
       with:
         go-version: 1.19.x
 
-    - name: Setup ko
-      uses: imjasonh/setup-ko@v0.6
-      with:
-        version: latest-release
+    - uses: imjasonh/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
       with:
         path: ./src/knative.dev/net-kourier
 
-    - name: Install KinD
-      run: |
-        set -x
-
-        # Disable swap otherwise memory enforcement doesn't work
-        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600009955324200
-        sudo swapoff -a
-        sudo rm -f /swapfile
-
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
-
-    - name: Create KinD Cluster
-      run: |
-        set -x
-
-        # KinD configuration.
-        cat > kind.yaml <<EOF
-        apiVersion: kind.x-k8s.io/v1alpha4
-        kind: Cluster
-        nodes:
-        - role: control-plane
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-        - role: worker
-          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
-
-        # This is needed in order to
-        # (1) support projected volumes with service account tokens. See
-        #     https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
-        # (2) use a random cluster suffix
-        kubeadmConfigPatches:
-          - |
-            kind: ClusterConfiguration
-            metadata:
-              name: config
-            apiServer:
-              extraArgs:
-                "service-account-issuer": "kubernetes.default.svc"
-                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
-            networking:
-              dnsDomain: "${CLUSTER_SUFFIX}"
-        EOF
-
-        # Create a cluster!
-        kind create cluster --config kind.yaml
+    - name: Setup KinD
+      uses: chainguard-dev/actions/setup-kind@main
+      with:
+        k8s-version: ${{ matrix.k8s-version }}
+        kind-worker-count: 1
+        cluster-suffix: "${CLUSTER_SUFFIX}"
 
     - name: Deploy certificates for upstream traffic
       if: matrix.upstream-tls == 'tls'


### PR DESCRIPTION
As per title, this patch cleans up kind e2e and upgrade.

* Basically same with https://github.com/knative-sandbox/net-istio/pull/1104 which uses KinD setup.
* The next v1.11 uses k8s 1.25 as the min version so bumps the k8s versions.
