### PR TITLE
Drop envoy 1.23 and start testing 1.25

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -27,8 +27,8 @@ jobs:
         gateway:
         - quay.io/maistra-dev/proxyv2-ubi8:2.3-latest
         - quay.io/maistra-dev/proxyv2-ubi8:2.4-latest
-        - docker.io/envoyproxy/envoy:v1.23-latest
         - docker.io/envoyproxy/envoy:v1.24-latest
+        - docker.io/envoyproxy/envoy:v1.25-latest
 
         upstream-tls:
         - plain

--- a/config/300-gateway.yaml
+++ b/config/300-gateway.yaml
@@ -50,7 +50,7 @@ spec:
             - --log-level info
           command:
             - /usr/local/bin/envoy
-          image: docker.io/envoyproxy/envoy:v1.23-latest
+          image: docker.io/envoyproxy/envoy:v1.24-latest
           name: kourier-gateway
           ports:
             - name: http2-external

--- a/test/timeout/timeout_test.go
+++ b/test/timeout/timeout_test.go
@@ -62,20 +62,18 @@ func TestIdleTimeout(t *testing.T) {
 
 	test := struct {
 		name         string
-		code         int
 		initialDelay time.Duration
 		delay        time.Duration
 	}{
 		name:         "100s delay before response",
-		code:         http.StatusRequestTimeout,
 		initialDelay: waitDuration,
 	}
 
-	checkTimeout(t, client, name, test.code, test.initialDelay, test.delay)
+	checkTimeout(t, client, name, test.initialDelay, test.delay)
 
 }
 
-func checkTimeout(t *testing.T, client *http.Client, name string, code int, initial time.Duration, timeout time.Duration) {
+func checkTimeout(t *testing.T, client *http.Client, name string, initial time.Duration, timeout time.Duration) {
 	reqURL := fmt.Sprintf("http://%s.example.com?initialTimeout=%d&timeout=%d",
 		name, initial.Milliseconds(), timeout.Milliseconds())
 	req, err := http.NewRequest("GET", reqURL, nil)
@@ -87,5 +85,5 @@ func checkTimeout(t *testing.T, client *http.Client, name string, code int, init
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	assert.Equal(t, resp.StatusCode, code)
+	assert.Equal(t, true, resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusGatewayTimeout)
 }


### PR DESCRIPTION
Fix https://github.com/knative-sandbox/net-kourier/issues/1015

Envoy 1.23 will be EOL in a few months - https://github.com/envoyproxy/envoy/blob/main/RELEASES.md#major-release-schedule
This patch drops 1.23 testing and use 1.24 as the default image. Then, start testing 1.25.

/cc @skonto @ReToCode @norbjd 