### PR TITLE
Bump actions/setup-go to v4

### DIFF
--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -43,10 +43,10 @@ jobs:
       with:
         go-version: 1.19.x
 
-    - uses: imjasonh/setup-ko@v0.6
+    - uses: ko-build/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ./src/knative.dev/net-kourier
         # Fetch all tags to determine the latest release version.

--- a/.github/workflows/kind-e2e-upgrade.yaml
+++ b/.github/workflows/kind-e2e-upgrade.yaml
@@ -38,15 +38,14 @@ jobs:
 
     steps:
     - name: Set up Go 1.19.x
-      # TODO: https://github.com/knative-sandbox/net-kourier/issues/1020
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.19.x
 
     - uses: ko-build/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         path: ./src/knative.dev/net-kourier
         # Fetch all tags to determine the latest release version.

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -47,10 +47,10 @@ jobs:
       with:
         go-version: 1.19.x
 
-    - uses: imjasonh/setup-ko@v0.6
+    - uses: ko-build/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ./src/knative.dev/net-kourier
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -50,7 +50,7 @@ jobs:
     - uses: ko-build/setup-ko@v0.6
 
     - name: Check out code onto GOPATH
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         path: ./src/knative.dev/net-kourier
 


### PR DESCRIPTION
This patch bumps actions/setup-go@v2 to v4 to fix #1020

Also it includes some cleaning up:
- use ko-build/setup-ko@v0.6 like https://github.com/knative/serving/pull/13951
- bumps actions/checkout@v3

Fix https://github.com/knative-sandbox/net-kourier/issues/1020