### PR TITLE
Set TLS 1.3 for min and max versions

### DIFF
--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -345,7 +345,8 @@ func createUpstreamTLSContext(caCertificate []byte, alpnProtocols ...string) *tl
 		CommonTlsContext: &tlsv3.CommonTlsContext{
 			AlpnProtocols: alpnProtocols,
 			TlsParams: &tlsv3.TlsParameters{
-				TlsMinimumProtocolVersion: tlsv3.TlsParameters_TLSv1_2,
+				TlsMinimumProtocolVersion: tlsv3.TlsParameters_TLSv1_3,
+				TlsMaximumProtocolVersion: tlsv3.TlsParameters_TLSv1_3,
 			},
 			ValidationContextType: &tlsv3.CommonTlsContext_ValidationContext{
 				ValidationContext: &tlsv3.CertificateValidationContext{

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -1646,7 +1646,8 @@ func typedConfig(http2 bool) *envoycorev3.TransportSocket_TypedConfig {
 		CommonTlsContext: &auth.CommonTlsContext{
 			AlpnProtocols: alpn,
 			TlsParams: &auth.TlsParameters{
-				TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_2,
+				TlsMinimumProtocolVersion: auth.TlsParameters_TLSv1_3,
+				TlsMaximumProtocolVersion: auth.TlsParameters_TLSv1_3,
 			},
 			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
 				ValidationContext: &auth.CertificateValidationContext{


### PR DESCRIPTION
This patch make a change that traffic from Kourier to Activator/QP uses TLS 1.3
when internal encryption is enabled.

Due to an issue of Envoy https://github.com/envoyproxy/envoy/issues/9300,
we need to set TLS 1.3 for min and max version.

Part of https://github.com/knative/serving/issues/14057

**Release Note**

```release-note
Traffic from Kourier to Activator/QP uses TLS 1.3 when internal encryption is enabled.
```

/cc @dprotaso @skonto @ReToCode 