### PR TITLE
Increase default QPS and Burst value to improve slow startup duration.

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -49,6 +49,10 @@ spec:
               value: ""
             - name: CERTS_SECRET_NAME
               value: ""
+            - name: KUBE_API_BURST
+              value: "200"
+            - name: KUBE_API_QPS
+              value: "200"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
:bug: This patch increases default QPS and Burst value to improve slow startup duration.

**Release Note**

```release-note
The default `kube-api-qps` and `kube-api-burst` are set to `200`. You can adjust them via env variable if necessary.
```

/cc @skonto @maschmid 