### PR TITLE
Revert "Add startup probe for controller (#1063)"

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -63,11 +63,6 @@ spec:
           - name: http2-xds
             containerPort: 18000
             protocol: TCP
-          startupProbe:
-            grpc:
-              port: 18000
-            periodSeconds: 10
-            failureThreshold: 120
           readinessProbe:
             grpc:
               port: 18000


### PR DESCRIPTION
This reverts commit 039e48afbca8d73223a59a29c0b5220cb74e4614.

Since https://github.com/knative-sandbox/net-kourier/pull/1066 fixes the root cause, the startup time is much faster even when there are many resources. There is no harm even if startup probe exists but we drop it because any other knative repo does not have it. 

/cc @ReToCode 
