### PR TITLE
Use informer for startupTranslator

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -214,16 +214,16 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	// resources at startup.
 	startupTranslator := generator.NewIngressTranslator(
 		func(ns, name string) (*corev1.Secret, error) {
-			return kubernetesClient.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{})
+			return secretInformer.Lister().Secrets(ns).Get(name)
 		},
 		func(ns, name string) (*corev1.Endpoints, error) {
-			return kubernetesClient.CoreV1().Endpoints(ns).Get(ctx, name, metav1.GetOptions{})
+			return endpointsInformer.Lister().Endpoints(ns).Get(name)
 		},
 		func(ns, name string) (*corev1.Service, error) {
-			return kubernetesClient.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+			return serviceInformer.Lister().Services(ns).Get(name)
 		},
 		func(name string) (*corev1.Namespace, error) {
-			return kubernetesClient.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+			return namespaceInformer.Lister().Get(name)
 		},
 		impl.Tracker)
 

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -210,8 +210,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 	logger.Infof("Priming the config with %d ingresses", len(ingressesToSync))
 
-	// The startup translator uses clients instead of listeners to correctly list all
-	// resources at startup.
 	startupTranslator := generator.NewIngressTranslator(
 		func(ns, name string) (*corev1.Secret, error) {
 			return secretInformer.Lister().Secrets(ns).Get(name)


### PR DESCRIPTION
This patch uses informer for `startupTranslator` instead of k8s client.

This is alternative of https://github.com/knative-sandbox/net-kourier/pull/1066