### PR TITLE
Drop rollout for e2e test which updates config-kourier

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -159,8 +159,6 @@ kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-
 
 echo ">> Setup Proxy Protocol"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type merge -p '{"data":{"enable-proxy-protocol":"true"}}'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running Proxy Protocol tests"
 go test -race -count=1 -timeout=5m -tags=e2e ./test/proxyprotocol/... \
@@ -170,13 +168,9 @@ go test -race -count=1 -timeout=5m -tags=e2e ./test/proxyprotocol/... \
 
 echo ">> Unset Proxy Protocol"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type merge -p '{"data":{"enable-proxy-protocol":"false"}}'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Set IdleTimeout to 50s"
 kubectl -n "${KOURIER_CONTROL_NAMESPACE}" patch configmap/config-kourier --type merge -p '{"data":{"stream-idle-timeout":"50s"}}'
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout restart deployment/net-kourier-controller
-kubectl -n "${KOURIER_CONTROL_NAMESPACE}" rollout status deployment/net-kourier-controller --timeout=300s
 
 echo ">> Running IdleTimeout tests"
 go test -v  -tags=e2e ./test/timeout/... \


### PR DESCRIPTION
This patch drops rollout for e2e test which updates config-kourier.

Since we don't need to restart net-kourier-controller when changing `config-kourier`, this patch removes the `rollout` commands.

The `rollout restart` should be added only for env variable change tests such as `*_EXTAUTHZ_` as it restarts controller and we need to wait until new pods are up.

/kind cleanup
