### PR TITLE
Fix an issue where getReadyIngresses was not loading ready ingresses at startup

### DIFF
--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -59,6 +59,10 @@ spec:
               value: "kourier-system"
             - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
               value: "false"
+            - name: KUBE_API_BURST
+              value: "200"
+            - name: KUBE_API_QPS
+              value: "200"
           ports:
           - name: http2-xds
             containerPort: 18000

--- a/config/300-controller.yaml
+++ b/config/300-controller.yaml
@@ -59,6 +59,9 @@ spec:
               value: "kourier-system"
             - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
               value: "false"
+            # KUBE_API_BURST and KUBE_API_QPS allows to configure maximum burst for throttle and maximum QPS to the server from the client.
+            # Setting these values using env vars is possible since https://github.com/knative/pkg/pull/2755.
+            # 200 is an arbitrary value, but it speeds up kourier startup duration, and the whole ingress reconciliation process as a whole.
             - name: KUBE_API_BURST
               value: "200"
             - name: KUBE_API_QPS

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -25,7 +25,6 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	v1 "k8s.io/client-go/informers/core/v1"
@@ -35,9 +34,10 @@ import (
 	"knative.dev/net-kourier/pkg/generator"
 	rconfig "knative.dev/net-kourier/pkg/reconciler/ingress/config"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	networkingClientSet "knative.dev/networking/pkg/client/clientset/versioned/typed/networking/v1alpha1"
+	knativeclient "knative.dev/networking/pkg/client/injection/client"
 	ingressinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress"
 	v1alpha1ingress "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/ingress"
-	ingresslister "knative.dev/networking/pkg/client/listers/networking/v1alpha1"
 	netconfig "knative.dev/networking/pkg/config"
 	"knative.dev/networking/pkg/status"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -71,6 +71,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	logger := logging.FromContext(ctx)
 
 	kubernetesClient := kubeclient.Get(ctx)
+	knativeClient := knativeclient.Get(ctx)
 	ingressInformer := ingressinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
@@ -203,7 +204,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	// Get the current list of ingresses that are ready and seed the Envoy config with them.
-	ingressesToSync, err := getReadyIngresses(ingressInformer.Lister())
+	ingressesToSync, err := getReadyIngresses(ctx, knativeClient.NetworkingV1alpha1())
 	if err != nil {
 		logger.Fatalw("Failed to fetch ready ingresses", zap.Error(err))
 	}
@@ -310,16 +311,16 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	return impl
 }
 
-func getReadyIngresses(ingressLister ingresslister.IngressLister) ([]*v1alpha1.Ingress, error) {
-	ingresses, err := ingressLister.List(labels.SelectorFromSet(map[string]string{
-		v1alpha1ingress.ClassAnnotationKey: config.KourierIngressClassName,
-	}))
+func getReadyIngresses(ctx context.Context, knativeClient networkingClientSet.NetworkingV1alpha1Interface) ([]*v1alpha1.Ingress, error) {
+	ingresses, err := knativeClient.Ingresses("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
-	ingressesToWarm := make([]*v1alpha1.Ingress, 0, len(ingresses))
-	for _, ingress := range ingresses {
-		if ingress.GetDeletionTimestamp() == nil && // Ignore ingresses that are already marked for deletion.
+	ingressesToWarm := make([]*v1alpha1.Ingress, 0, len(ingresses.Items))
+	for i := range ingresses.Items {
+		ingress := &ingresses.Items[i]
+		if isKourierIngress(ingress) &&
+			ingress.GetDeletionTimestamp() == nil && // Ignore ingresses that are already marked for deletion.
 			ingress.GetStatus().GetCondition(v1alpha1.IngressConditionNetworkConfigured).IsTrue() {
 			ingressesToWarm = append(ingressesToWarm, ingress)
 		}


### PR DESCRIPTION
# Changes

- :bug: fix `getReadyIngresses` not loading ingresses at startup

/kind bug

I've noticed that with latest kourier release (1.11.0), kourier was not loading at all ready ingresses at startup. This was confirmed by looking at the logs, after restarting the controller on a cluster with a few ready ingresses:

```
Priming the config with 0 ingresses
```

This log is generated by https://github.com/knative-sandbox/net-kourier/blob/knative-v1.11.0/pkg/reconciler/ingress/controller.go#L210. I would have expected to see `Priming the config with 100 ingresses`, as my cluster contained 100 ingresses.

After investigation, it turns out that the PR https://github.com/knative-sandbox/net-kourier/pull/1075 introduced a regression on `getReadyIngresses` method (https://github.com/knative-sandbox/net-kourier/blob/knative-v1.11.0/pkg/reconciler/ingress/controller.go#L313-L327):

```go
ingresses, err := ingressLister.List(labels.SelectorFromSet(map[string]string{
        v1alpha1ingress.ClassAnnotationKey: config.KourierIngressClassName,
}))
```

This can't work, because we're passing an **annotation** (`networking.knative.dev/ingress.class: kourier.ingress.networking.knative.dev`), while `List` method is actually filtering using **labels**. As a result, this `List` operation will always return an empty slice.

So _technically_, https://github.com/knative-sandbox/net-kourier/pull/1075 solves the issue where kourier takes too long to start, but it's due to a bug: since there are always 0 ingress returned, there is no initial reconciliation; thus, the xds management server is started very quickly, and the readiness probe succeeds, marking kourier as ready pretty fast.

This PR aims to solves this bug. But, as I've rollbacked to the previous version of `getReadyIngresses`, I've "reintroduced" the slow startup issue (because it's loading all ingresses, as it should do I guess). This is why I've also copied here the changes done in https://github.com/knative-sandbox/net-kourier/pull/1066 (on kube api QPS and burst params).

With these 2 changes, kourier loads **all** ready ingresses at startup and is pretty quick to start.

I'm not sure if introducing `KUBE_API_{BURST,QPM}` on this PR is a good thing or not; but, I've done so because otherwise, I couldn't even restart kourier on a kind cluster with 500 ingresses (got errors, probably because I was rate limited by Kubernetes API).

## Tests

With these changes, on a Kind cluster with 500 ingresses, Kourier took around 1s to restart and to be ready (after reloading the 500 ingresses, I can see the correct log `Priming the config with 500 ingresses`).

It's worth noting that increasing `KUBE_API_{BURST,QPM}` has a side effect on kourier in general: it allows to speed up the ingresses creation. I've tried creating 500 ingresses on a Kind cluster (in parallel, with a concurrency limit of 20), here are the results:

- on `main` branch: it took 8m18s to create the ingresses. Creating 1 ingress took around 20s, as I were creating 20 ingresses at a time in parallel
- with this PR (`KUBE_API_{BURST,QPM}=200`): it takes 20s (25x less) to create all 500 ingresses, with the same parallelism

**Release Note**

```release-note
Fix an issue where kourier was not reloading ingresses at startup
```